### PR TITLE
Add back layout files to dir tree

### DIFF
--- a/DataModel/src/org/sleuthkit/autopsy/datamodel/ContentChildren.java
+++ b/DataModel/src/org/sleuthkit/autopsy/datamodel/ContentChildren.java
@@ -42,13 +42,13 @@ class ContentChildren extends AbstractContentChildren {
         List<Content> children = ContentHierarchyVisitor.getChildren(parent);
         
         // To not display LayoutFiles
-        Iterator<Content> it = children.iterator();
-        while(it.hasNext()) {
-            Content child = it.next();
-            if(child instanceof LayoutFile) {
-                it.remove();
-            }
-        }
+//        Iterator<Content> it = children.iterator();
+//        while(it.hasNext()) {
+//            Content child = it.next();
+//            if(child instanceof LayoutFile) {
+//                it.remove();
+//            }
+//        }
         
         setKeys(children.subList(0, Math.min(children.size(), MAX_CHILD_COUNT)));
     }


### PR DESCRIPTION
Dir tree will now load first 10k Content children, be they volumes,
layout files, files, dirs, etc.

Leaving the code that did this commented out for now, in case we need it back in the future
