### PR TITLE
Fix build on Linux systems

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -180,7 +180,7 @@
         </propertyfile>
         
         <propertyfile
-        file="${basedir}/Core/src/org/sleuthkit/autopsy/CoreUtils/Version.properties"
+        file="${basedir}/Core/src/org/sleuthkit/autopsy/coreutils/Version.properties"
         comment="Updated by build script">
             <entry key="app.name" value="${app.title}" />
             <entry key="app.version" value="${app.version}" />

--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -31,4 +31,4 @@ project.org.sleuthkit.autopsy.keywordsearch=KeywordSearch
 project.org.sleuthkit.autopsy.recentactivity=RecentActivity
 project.org.sleuthkit.autopsy.testing=Testing
 project.org.sleuthkit.autopsy.thunderbirdparser=thunderbirdparser
-project.org.sleuthkit.autopsy.exifparser=exifparser
+project.org.sleuthkit.autopsy.exifparser=ExifParser


### PR DESCRIPTION
Linux builds are case-sensitive, so the directory names needed to be fixed in a few places.
