### PR TITLE
Hide Compiler Warnings

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/report/ReportBodyFile.java
+++ b/Core/src/org/sleuthkit/autopsy/report/ReportBodyFile.java
@@ -67,6 +67,7 @@ public class ReportBodyFile implements GeneralReportModule {
      * @param progressPanel panel to update the report's progress
      */
     @Override
+    @SuppressWarnings("deprecation")
     public void generateReport(String path, ReportProgressPanel progressPanel) {
         // Start the progress bar and setup the report
         progressPanel.setIndeterminate(false);

--- a/Core/src/org/sleuthkit/autopsy/report/ReportGenerator.java
+++ b/Core/src/org/sleuthkit/autopsy/report/ReportGenerator.java
@@ -410,6 +410,7 @@ public class ReportGenerator {
      * Write the keyword hits to the provided TableReportModules.
      * @param tableModules modules to report on
      */
+    @SuppressWarnings("deprecation")
     private void writeKeywordHits(List<TableReportModule> tableModules) {
         ResultSet listsRs = null;
         try {
@@ -546,6 +547,7 @@ public class ReportGenerator {
      * Write the hashset hits to the provided TableReportModules.
      * @param tableModules modules to report on
      */
+    @SuppressWarnings("deprecation")
     private void writeHashsetHits(List<TableReportModule> tableModules) {
         ResultSet listsRs = null;
         try {

--- a/Core/src/org/sleuthkit/autopsy/report/ReportWizardAction.java
+++ b/Core/src/org/sleuthkit/autopsy/report/ReportWizardAction.java
@@ -97,6 +97,7 @@ public final class ReportWizardAction  extends CallableSystemAction implements P
      * and start all necessary reports.
      */
     @Override
+    @SuppressWarnings("unchecked")
     public void actionPerformed(ActionEvent e) {
         // Create the wizard
         WizardDescriptor wiz = new WizardDescriptor(new ReportWizardIterator());
@@ -106,15 +107,26 @@ public final class ReportWizardAction  extends CallableSystemAction implements P
         // When the user presses the finish button
         if (DialogDisplayer.getDefault().notify(wiz) == WizardDescriptor.FINISH_OPTION) {
             // Get the wizard information
-            Map<TableReportModule, Boolean> tableModuleStates = (Map<TableReportModule, Boolean>) wiz.getProperty("tableModuleStates");
-            Map<GeneralReportModule, Boolean> generalModuleStates = (Map<GeneralReportModule, Boolean>) wiz.getProperty("generalModuleStates");
+            Object wizProp1 = wiz.getProperty("tableModuleStates");
+            Object wizProp2 = wiz.getProperty("generalModuleStates");
+            Object wizProp3 = wiz.getProperty("isTagsSelected");
+            Object wizProp4 = wiz.getProperty("tagStates");
+            Object wizProp5 = wiz.getProperty("artifactStates");
+            
+            // Initialize varibales
+            Map<TableReportModule, Boolean> tableModuleStates = (Map<TableReportModule, Boolean>) wizProp1;
+            Map<GeneralReportModule, Boolean> generalModuleStates = (Map<GeneralReportModule, Boolean>) wizProp2;
+            Boolean isTagsSelected = (Boolean) wizProp3;
+            Map<String, Boolean> tagStates = (Map<String, Boolean>) wizProp4;
+            Map<ARTIFACT_TYPE, Boolean> artifactStates = (Map<ARTIFACT_TYPE, Boolean>) wizProp5;
+
             // Create the generator and generate reports
             ReportGenerator generator = new ReportGenerator(tableModuleStates, generalModuleStates);
-            if (wiz.getProperty("isTagsSelected") != null) {
-                if ((Boolean) wiz.getProperty("isTagsSelected")) {
-                    generator.generateTableTagReport((Map<String, Boolean>) wiz.getProperty("tagStates"));
+            if (isTagsSelected != null) {
+                if (isTagsSelected) {
+                    generator.generateTableTagReport(tagStates);
                 } else {
-                    generator.generateTableArtifactReport((Map<ARTIFACT_TYPE, Boolean>) wiz.getProperty("artifactStates"));
+                    generator.generateTableArtifactReport(artifactStates);
                 }
             }
             generator.generateGeneralReports();


### PR DESCRIPTION
Added @Suppress statements to hide the warnings. All warnings given are safe as we are manually assigning and retrieving the objects.
