### PR TITLE
Changes to IngestDialogPanel to facilitate reuse

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/core/layer.xml
+++ b/Core/src/org/sleuthkit/autopsy/core/layer.xml
@@ -287,11 +287,6 @@
             <attr name="instanceOf" stringvalue="org.sleuthkit.autopsy.directorytree.FileSearchProvider"/>
             <attr name="position" intvalue="250"/>
         </file>
-        <file name="org-sleuthkit-autopsy-ingest-IngestDialogPanel.instance">
-            <attr name="instanceOf" stringvalue="org.sleuthkit.autopsy.casemodule.IngestConfigurator"/>
-            <attr name="instanceCreate" methodvalue="org.sleuthkit.autopsy.ingest.IngestDialogPanel.getDefault"/>
-            <attr name="position" intvalue="50"/> 
-        </file>
         <file name="org-sleuthkit-autopsy-report-ReportHTML.instance">
             <attr name="instanceOf" stringvalue="org.sleuthkit.autopsy.report.TableReportModule"/>
             <attr name="instanceCreate" methodvalue="org.sleuthkit.autopsy.report.ReportHTML.getDefault"/>

--- a/Core/src/org/sleuthkit/autopsy/ingest/IngestDialog.java
+++ b/Core/src/org/sleuthkit/autopsy/ingest/IngestDialog.java
@@ -47,7 +47,7 @@ public class IngestDialog extends JDialog {
 
     public IngestDialog(JFrame frame, String title, boolean modal) {
         super(frame, title, modal);
-        panel = IngestDialogPanel.getDefault();
+        panel = new IngestDialogPanel();
     }
     
     public IngestDialog(){

--- a/Core/src/org/sleuthkit/autopsy/ingest/IngestDialogPanel.java
+++ b/Core/src/org/sleuthkit/autopsy/ingest/IngestDialogPanel.java
@@ -33,7 +33,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
-import javax.swing.JCheckBox;
 import org.sleuthkit.autopsy.coreutils.Logger;
 import javax.swing.JPanel;
 import javax.swing.JTable;
@@ -43,7 +42,7 @@ import javax.swing.event.ListSelectionListener;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableColumn;
-import org.openide.util.Exceptions;
+import org.openide.util.lookup.ServiceProvider;
 import org.sleuthkit.autopsy.casemodule.IngestConfigurator;
 import org.sleuthkit.autopsy.corecomponents.AdvancedConfigurationDialog;
 import org.sleuthkit.autopsy.coreutils.ModuleSettings;
@@ -52,6 +51,7 @@ import org.sleuthkit.datamodel.Image;
 /**
  * main configuration panel for all ingest modules, reusable JPanel component
  */
+@ServiceProvider(service = IngestConfigurator.class)
 public class IngestDialogPanel extends javax.swing.JPanel implements IngestConfigurator {
 
     private IngestManager manager = null;
@@ -64,10 +64,9 @@ public class IngestDialogPanel extends javax.swing.JPanel implements IngestConfi
     public static final String PARSE_UNALLOC = "Process_Unallocated_Space";
     // The image that's just been added to the database
     private Image image;
-    private static IngestDialogPanel instance = null;
 
     /** Creates new form IngestDialogPanel */
-    private IngestDialogPanel() {
+    public IngestDialogPanel() {
         tableModel = new ModulesTableModel();
         modules = new ArrayList<IngestModuleAbstract>();
         moduleStates = new HashMap<String, Boolean>();
@@ -75,13 +74,6 @@ public class IngestDialogPanel extends javax.swing.JPanel implements IngestConfi
         customizeComponents();
     }
 
-    synchronized static IngestDialogPanel getDefault() {
-        if (instance == null) {
-            instance = new IngestDialogPanel();
-        }
-        return instance;
-    }
-    
     private void loadModules() {
         this.modules.clear();
         //this.moduleStates.clear(); maintain the state

--- a/Core/src/org/sleuthkit/autopsy/ingest/IngestManager.java
+++ b/Core/src/org/sleuthkit/autopsy/ingest/IngestManager.java
@@ -75,7 +75,7 @@ public class IngestManager {
     //module loader
     private IngestModuleLoader moduleLoader = null;
     //property file name id for the module
-    final static String MODULE_PROPERTIES = "ingest";
+    public final static String MODULE_PROPERTIES = "ingest";
 
     /**
      * Possible events about ingest modules Event listeners can get the event


### PR DESCRIPTION
Removed use of singleton pattern from IngestDialogPanel so that one can be instantiated by any client code.
