### PR TITLE
Added missing resources to corecomponents Bundle.

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/corecomponents/Bundle.properties
+++ b/Core/src/org/sleuthkit/autopsy/corecomponents/Bundle.properties
@@ -106,3 +106,6 @@ MediaViewVideoPanel.pauseButton.text=\u25ba
 MediaViewVideoPanel.progressLabel.text=00:00
 DataContentViewerMedia.AccessibleContext.accessibleDescription=
 MediaViewVideoPanel.infoLabel.text=info
+GeneralPanel.jLabel2.text=When displaying times:
+GeneralPanel.useLocalTimeRB.text=Use local timezone
+GeneralPanel.useGMTTimeRB.text=Use GMT


### PR DESCRIPTION
When I submitted the Timezone Option, I forgot to include the Bundle.properties file that holds the text for the new parts of the options panel.
