### PR TITLE
Fixed redundant calls to setupTable/tabs due to node listener.

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/corecomponents/DataResultPanel.java
+++ b/Core/src/org/sleuthkit/autopsy/corecomponents/DataResultPanel.java
@@ -612,19 +612,23 @@ public class DataResultPanel extends javax.swing.JPanel implements DataResult, C
     
     private class DummyNodeListener implements NodeListener {
         private static final String DUMMY_NODE_DISPLAY_NAME = "Please Wait...";
+        private boolean reload = false;
         
         @Override
         public void childrenAdded(final NodeMemberEvent nme) {
-            Node added = nme.getNode();
-            if (added.getDisplayName().equals(DUMMY_NODE_DISPLAY_NAME)) {
-                // don't set up tabs if the new node is a waiting node
-                return;
+            if (reload) {
+                setupTabs(nme.getNode());
+                reload = false;
             }
-            setupTabs(nme.getNode());
         }
 
         @Override
         public void childrenRemoved(NodeMemberEvent nme) {
+            Node removed = nme.getNode();
+            if (removed.getDisplayName().equals(DUMMY_NODE_DISPLAY_NAME)) {
+                // set up tabs if the node removed is a waiting node
+                reload = false;
+            }
         }
 
         @Override

--- a/Core/src/org/sleuthkit/autopsy/corecomponents/DataResultViewerTable.java
+++ b/Core/src/org/sleuthkit/autopsy/corecomponents/DataResultViewerTable.java
@@ -478,21 +478,21 @@ public class DataResultViewerTable extends AbstractDataResultViewer {
     
     private class DummyNodeListener implements NodeListener {
         private static final String DUMMY_NODE_DISPLAY_NAME = "Please Wait...";
-        
+        private boolean reload = false;
         @Override
         public void childrenAdded(NodeMemberEvent nme) {
-            Node added = nme.getNode();
-            if (added.getDisplayName().equals(DUMMY_NODE_DISPLAY_NAME)) {
-                // If it's the dummy waiting node, we don't want
-                // to reload the table headers
-                return;
+            if (reload = true) {
+                setupTable(nme.getNode());
+                reload = false;
             }
-            setupTable(added);
         }
 
         @Override
         public void childrenRemoved(NodeMemberEvent nme) {
-            
+            Node removed = nme.getNode();
+            if (removed.getDisplayName().equals(DUMMY_NODE_DISPLAY_NAME)) {
+                reload = true;
+            }
         }
 
         @Override


### PR DESCRIPTION
When explaining the lazy loading children to Richard, we discovered that there were redundant calls to setupTables/Tabs because of the NodeListener that monitors the waiting node displayed while the children are being created in a background thread. This removes those extra calls.
