### PR TITLE
Fixed redundant calls

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/corecomponents/DataResultPanel.java
+++ b/Core/src/org/sleuthkit/autopsy/corecomponents/DataResultPanel.java
@@ -358,6 +358,7 @@ public class DataResultPanel extends javax.swing.JPanel implements DataResult, C
                 
         this.rootNode = selectedNode;
         if (this.rootNode != null) {
+            dummyNodeListener.reset();
             this.rootNode.addNodeListener(dummyNodeListener);
         }
         
@@ -612,23 +613,32 @@ public class DataResultPanel extends javax.swing.JPanel implements DataResult, C
     
     private class DummyNodeListener implements NodeListener {
         private static final String DUMMY_NODE_DISPLAY_NAME = "Please Wait...";
-        private boolean reload = false;
+        private volatile boolean load = true;
+        
+        public void reset() {
+            load = true;
+        }
         
         @Override
-        public void childrenAdded(final NodeMemberEvent nme) {
-            if (reload) {
+        public void childrenAdded(NodeMemberEvent nme) {
+            Node[] delta = nme.getDelta();
+            if (load && containsReal(delta)) {
+                load = false;
                 setupTabs(nme.getNode());
-                reload = false;
             }
+        }
+        
+        private boolean containsReal(Node[] delta) {
+            for (Node n : delta) {
+                if (!n.getDisplayName().equals(DUMMY_NODE_DISPLAY_NAME)) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         @Override
         public void childrenRemoved(NodeMemberEvent nme) {
-            Node removed = nme.getNode();
-            if (removed.getDisplayName().equals(DUMMY_NODE_DISPLAY_NAME)) {
-                // set up tabs if the node removed is a waiting node
-                reload = false;
-            }
         }
 
         @Override

--- a/Core/src/org/sleuthkit/autopsy/corecomponents/DataResultViewerTable.java
+++ b/Core/src/org/sleuthkit/autopsy/corecomponents/DataResultViewerTable.java
@@ -243,8 +243,7 @@ public class DataResultViewerTable extends AbstractDataResultViewer {
         this.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
         try {
             boolean hasChildren = false;
-
-
+            
             if (selectedNode != null) {
                 hasChildren = selectedNode.getChildren().getNodesCount() > 0;
             }
@@ -257,6 +256,7 @@ public class DataResultViewerTable extends AbstractDataResultViewer {
             // if there's no selection node, do nothing
             if (hasChildren) {
                 Node root = selectedNode;
+                dummyNodeListener.reset();
                 root.addNodeListener(dummyNodeListener);
                 setupTable(root);
             } else {
@@ -478,21 +478,32 @@ public class DataResultViewerTable extends AbstractDataResultViewer {
     
     private class DummyNodeListener implements NodeListener {
         private static final String DUMMY_NODE_DISPLAY_NAME = "Please Wait...";
-        private boolean reload = false;
+        private volatile boolean load = true;
+        
+        public void reset() {
+            load = true;
+        }
+        
         @Override
         public void childrenAdded(NodeMemberEvent nme) {
-            if (reload) {
+            Node[] delta = nme.getDelta();
+            if (load && containsReal(delta)) {
+                load = false;
                 setupTable(nme.getNode());
-                reload = false;
             }
+        }
+        
+        private boolean containsReal(Node[] delta) {
+            for (Node n : delta) {
+                if (!n.getDisplayName().equals(DUMMY_NODE_DISPLAY_NAME)) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         @Override
         public void childrenRemoved(NodeMemberEvent nme) {
-            Node removed = nme.getNode();
-            if (removed.getDisplayName().equals(DUMMY_NODE_DISPLAY_NAME)) {
-                reload = true;
-            }
         }
 
         @Override


### PR DESCRIPTION
Realized there was an issue with my previous fix when certain kinds of nodes were given to data result viewers (specifically keyword search result nodes). This fixes that issue. There are still some extra calls due to multiple calls of setNode, but this fix minimizes the extra calls as much as possible without fixing that issue.
