### PR TITLE
Repair to HashDbManager.addHashDatabase()

### DIFF
--- a/HashDatabase/src/org/sleuthkit/autopsy/hashdatabase/HashDbManager.java
+++ b/HashDatabase/src/org/sleuthkit/autopsy/hashdatabase/HashDbManager.java
@@ -206,7 +206,7 @@ public class HashDbManager {
         // and the same database is not added to the configuration more than once.
         hashSetNames.add(hashDb.getHashSetName());
         hashSetPaths.add(indexPath);
-        if (hasIndexOnly) {
+        if (!hasIndexOnly) {
             hashSetPaths.add(databasePath);
         }
         


### PR DESCRIPTION
Fixed bug introduced in recently improved version of HashDbManager.addHashDatabase(). Inadvertantly dropped "!" operator.
