### PR TITLE
Adapt hashdb, keywordsearch config panels for wider use

### DIFF
--- a/HashDatabase/src/org/sleuthkit/autopsy/hashdatabase/HashDatabaseOptionsPanelController.java
+++ b/HashDatabase/src/org/sleuthkit/autopsy/hashdatabase/HashDatabaseOptionsPanelController.java
@@ -54,8 +54,7 @@ public final class HashDatabaseOptionsPanelController extends OptionsPanelContro
 
     @Override
     public void cancel() {
-        // Reset the XML on cancel
-        HashDbManager.getInstance().loadLastSavedConfiguration();
+        getPanel().cancel();
     }
 
     @Override

--- a/HashDatabase/src/org/sleuthkit/autopsy/hashdatabase/HashDbConfigPanel.java
+++ b/HashDatabase/src/org/sleuthkit/autopsy/hashdatabase/HashDbConfigPanel.java
@@ -262,6 +262,10 @@ public final class HashDbConfigPanel extends javax.swing.JPanel implements Optio
         hashSetManager.save();        
     }
     
+    public void cancel() {
+        HashDbManager.getInstance().loadLastSavedConfiguration();                        
+    }
+    
     void removeThese(List<HashDb> toRemove) {
         for (HashDb hashDb : toRemove) {
             hashSetManager.removeHashDatabase(hashDb);

--- a/HashDatabase/src/org/sleuthkit/autopsy/hashdatabase/HashDbIngestModule.java
+++ b/HashDatabase/src/org/sleuthkit/autopsy/hashdatabase/HashDbIngestModule.java
@@ -108,7 +108,7 @@ public class HashDbIngestModule extends IngestModuleAbstractFile {
     @Override
     public void saveSimpleConfiguration() {
         if (simpleConfigPanel != null) {
-            simpleConfigPanel.save();
+            simpleConfigPanel.store();
         }
     }
     

--- a/HashDatabase/src/org/sleuthkit/autopsy/hashdatabase/HashDbSimpleConfigPanel.java
+++ b/HashDatabase/src/org/sleuthkit/autopsy/hashdatabase/HashDbSimpleConfigPanel.java
@@ -41,7 +41,7 @@ public class HashDbSimpleConfigPanel extends javax.swing.JPanel {
     private HashDatabasesTableModel knownTableModel;
     private HashDatabasesTableModel knownBadTableModel;
 
-    HashDbSimpleConfigPanel() {
+    public HashDbSimpleConfigPanel() {
         knownTableModel = new HashDatabasesTableModel(HashDbManager.HashDb.KnownFilesType.KNOWN);
         knownBadTableModel = new HashDatabasesTableModel(HashDbManager.HashDb.KnownFilesType.KNOWN_BAD);
         initComponents();
@@ -83,12 +83,12 @@ public class HashDbSimpleConfigPanel extends javax.swing.JPanel {
         }        
     }
     
-    void load() {        
+    public void load() {        
         knownTableModel.load();
         knownBadTableModel.load();
     }
 
-    void save() {
+    public void store() {
         HashDbManager.getInstance().save();        
     }
             

--- a/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/KeywordSearchConfigurationPanel.java
+++ b/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/KeywordSearchConfigurationPanel.java
@@ -1,7 +1,7 @@
 /*
  * Autopsy Forensic Browser
  *
- * Copyright 2011 Basis Technology Corp.
+ * Copyright 2011 - 2013 Basis Technology Corp.
  * Contact: carrier <at> sleuthkit <dot> org
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,21 +19,18 @@
 
 package org.sleuthkit.autopsy.keywordsearch;
 
-import java.util.logging.Level;
-import org.sleuthkit.autopsy.coreutils.Logger;
 import org.sleuthkit.autopsy.corecomponents.OptionsPanel;
 
 /**
  * Container panel for keyword search advanced configuration options
  */
-final class KeywordSearchConfigurationPanel extends javax.swing.JPanel implements OptionsPanel {
+public final class KeywordSearchConfigurationPanel extends javax.swing.JPanel implements OptionsPanel {
 
-    private static final Logger logger = Logger.getLogger(KeywordSearchConfigurationPanel.class.getName());
     private KeywordSearchConfigurationPanel1 listsPanel;
     private KeywordSearchConfigurationPanel3 languagesPanel;
     private KeywordSearchConfigurationPanel2 generalPanel;
 
-    KeywordSearchConfigurationPanel() {
+    public KeywordSearchConfigurationPanel() {
         initComponents();
         customizeComponents();
     }
@@ -45,8 +42,7 @@ final class KeywordSearchConfigurationPanel extends javax.swing.JPanel implement
         generalPanel = new KeywordSearchConfigurationPanel2();
         tabbedPane.insertTab("Lists", null, listsPanel, "List configuration", 0);
         tabbedPane.insertTab("String Extraction", null, languagesPanel, "String extraction configuration for Keyword Search Ingest", 1);
-        tabbedPane.insertTab("General", null, generalPanel, "General configuration", 2);
-        
+        tabbedPane.insertTab("General", null, generalPanel, "General configuration", 2);        
     }
 
     /**
@@ -94,10 +90,15 @@ final class KeywordSearchConfigurationPanel extends javax.swing.JPanel implement
         generalPanel.store();
     }
 
+    public void cancel() {
+        KeywordSearchListsXML.getCurrent().reload();        
+    }
+    
     boolean valid() {
         // TODO check whether form is consistent and complete
         return true;
     }
+    
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JTabbedPane tabbedPane;
     // End of variables declaration//GEN-END:variables

--- a/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/KeywordSearchIngestSimplePanel.java
+++ b/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/KeywordSearchIngestSimplePanel.java
@@ -1,7 +1,7 @@
 /*
  * Autopsy Forensic Browser
  * 
- * Copyright 2011 Basis Technology Corp.
+ * Copyright 2011 - 2013 Basis Technology Corp.
  * Contact: carrier <at> sleuthkit <dot> org
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,7 +27,6 @@ import org.sleuthkit.autopsy.coreutils.Logger;
 import javax.swing.ListSelectionModel;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableColumn;
-import org.sleuthkit.autopsy.coreutils.ModuleSettings;
 import org.sleuthkit.autopsy.coreutils.StringExtract.StringExtractUnicodeTable.SCRIPT;
 
 /**
@@ -71,6 +70,16 @@ public class KeywordSearchIngestSimplePanel extends javax.swing.JPanel {
         reloadEncodings();
     }
 
+    public void load() {        
+        reloadLists();
+        reloadLangs();
+        reloadEncodings();
+    }
+
+    public void store() {
+        KeywordSearchListsXML.getCurrent().save();
+    }
+                
     /** This method is called from within the constructor to
      * initialize the form.
      * WARNING: Do NOT modify this code. The content of this method is

--- a/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/KeywordSearchOptionsPanelController.java
+++ b/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/KeywordSearchOptionsPanelController.java
@@ -35,8 +35,7 @@ public final class KeywordSearchOptionsPanelController extends OptionsPanelContr
     }
 
     public void cancel() {
-        // Reload XML on cancel
-        KeywordSearchListsXML.getCurrent().reload();
+        getPanel().cancel();
     }
 
     public boolean isValid() {


### PR DESCRIPTION
Made these core configuration mechanisms uniform in support for wider use.
The simple and advanced config panels are now all public with public load/store methods.
