### PR TITLE
moved jpeg header check method to public image utils class.

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/contentviewers/Utilities.java
+++ b/Core/src/org/sleuthkit/autopsy/contentviewers/Utilities.java
@@ -30,39 +30,6 @@ import org.sleuthkit.datamodel.TskCoreException;
  */
 public class Utilities {
 
-    /**
-     * Check if is jpeg file based on header
-     *
-     * @param file
-     *
-     * @return true if jpeg file, false otherwise
-     */
-    public static boolean isJpegFileHeader(AbstractFile file) {
-        if (file.getSize() < 100) {
-            return false;
-        }
-
-        byte[] fileHeaderBuffer = new byte[2];
-        int bytesRead;
-        try {
-            bytesRead = file.read(fileHeaderBuffer, 0, 2);
-        } catch (TskCoreException ex) {
-            //ignore if can't read the first few bytes, not a JPEG
-            return false;
-        }
-        if (bytesRead != 2) {
-            return false;
-        }
-        /*
-         * Check for the JPEG header. Since Java bytes are signed, we cast them
-         * to an int first.
-         */
-        if (((int) (fileHeaderBuffer[0] & 0xff) == 0xff) && ((int) (fileHeaderBuffer[1] & 0xff) == 0xd8)) {
-            return true;
-        }
-        return false;
-    }
-
     public static void configureTextPaneAsHtml(JTextPane pane) {
         pane.setContentType("text/html;charset=UTF-8");
         HTMLEditorKit kit = new HTMLEditorKit();

--- a/Core/src/org/sleuthkit/autopsy/corecomponents/DataContentViewerMedia.java
+++ b/Core/src/org/sleuthkit/autopsy/corecomponents/DataContentViewerMedia.java
@@ -28,8 +28,8 @@ import org.sleuthkit.autopsy.coreutils.Logger;
 import org.openide.nodes.Node;
 import org.openide.util.lookup.ServiceProvider;
 import org.openide.util.lookup.ServiceProviders;
-import org.sleuthkit.autopsy.contentviewers.Utilities;
 import org.sleuthkit.autopsy.corecomponentinterfaces.DataContentViewer;
+import org.sleuthkit.autopsy.coreutils.ImageUtils;
 import org.sleuthkit.datamodel.AbstractFile;
 import org.sleuthkit.datamodel.TskData.TSK_FS_NAME_FLAG_ENUM;
 
@@ -133,7 +133,7 @@ public class DataContentViewerMedia extends javax.swing.JPanel implements DataCo
             if (imagePanelInited && containsExt(file.getName(), imageExtensions)) {
                 imagePanel.showImageFx(file, dims);
                 this.switchPanels(false);
-            } else if (imagePanelInited && Utilities.isJpegFileHeader(file)) {
+            } else if (imagePanelInited && ImageUtils.isJpegFileHeader(file)) {
 
                 imagePanel.showImageFx(file, dims);
                 this.switchPanels(false);
@@ -208,7 +208,7 @@ public class DataContentViewerMedia extends javax.swing.JPanel implements DataCo
             if (containsExt(name, imageExtensions)) {
                 return true;
             }
-            else if (Utilities.isJpegFileHeader(file)) {
+            else if (ImageUtils.isJpegFileHeader(file)) {
                 return true;
             }
             //for gstreamer formats, check if initialized first, then

--- a/ExifParser/src/org/sleuthkit/autopsy/exifparser/ExifParserFileIngestModule.java
+++ b/ExifParser/src/org/sleuthkit/autopsy/exifparser/ExifParserFileIngestModule.java
@@ -33,7 +33,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.logging.Level;
-import org.sleuthkit.autopsy.contentviewers.Utilities;
+import org.sleuthkit.autopsy.coreutils.ImageUtils;
 import org.sleuthkit.autopsy.coreutils.Logger;
 import org.sleuthkit.autopsy.coreutils.Version;
 import org.sleuthkit.autopsy.ingest.PipelineContext;
@@ -198,7 +198,7 @@ public final class ExifParserFileIngestModule extends IngestModuleAbstractFile {
      * @return true if to be processed
      */
     private boolean parsableFormat(AbstractFile f) {
-        return Utilities.isJpegFileHeader(f);
+        return ImageUtils.isJpegFileHeader(f);
     }
 
     @Override


### PR DESCRIPTION
- Previous caused compilation error when merged with develop because the previous class of the jpeg header check method (Utilities) is not public outside autopsy-core.
