### PR TITLE
Fixed bug in comment attrs for hash set hit artifacts

### DIFF
--- a/HashDatabase/src/org/sleuthkit/autopsy/hashdatabase/HashDbIngestModule.java
+++ b/HashDatabase/src/org/sleuthkit/autopsy/hashdatabase/HashDbIngestModule.java
@@ -237,10 +237,10 @@ public class HashDbIngestModule extends IngestModuleAbstractFile {
                     ArrayList<String> comments = hashInfo.getComments();
                     int i = 0;
                     for (String c : comments) {
-                        comment += c;
                         if (++i > 1) {
-                            c += ". ";
+                            comment += " ";
                         }
+                        comment += c;
                         if (comment.length() > MAX_COMMENT_SIZE) {
                             comment = comment.substring(0, MAX_COMMENT_SIZE) + "...";
                             break;


### PR DESCRIPTION
Comments were not correctly concatenated and the comment separation character was likely to appear in comments. 
