### PR TITLE
Fixed name mismatch between UI and develop branch.

### DIFF
--- a/Testing/test/qa-functional/src/org/sleuthkit/autopsy/testing/RegressionTest.java
+++ b/Testing/test/qa-functional/src/org/sleuthkit/autopsy/testing/RegressionTest.java
@@ -182,7 +182,7 @@ public class RegressionTest extends TestCase {
 
     public void testConfigureHash() {
         logger.info("Hash Configure");
-        JDialog hashMainDialog = JDialogOperator.waitJDialog("Hash Database Configuration", false, false);
+        JDialog hashMainDialog = JDialogOperator.waitJDialog("Hash Set Configuration", false, false);
         JDialogOperator hashMainDialogOperator = new JDialogOperator(hashMainDialog);
         List<String> databases = new ArrayList<String>();
         databases.add(System.getProperty("nsrl_path"));


### PR DESCRIPTION
Somewhere along the line, a dialogue got renamed. The test script was not updated to reflect this, so the develop branch testing could not complete. This change should fix that, but cannot be tested until after it is pull requested due to the "chicken and egg" problem testing has been having.
