### PR TITLE
Fix saving of ingest module settings, change file ext mismatch module na...

### DIFF
--- a/FileExtMismatch/src/org/sleuthkit/autopsy/fileextmismatch/FileExtMismatchIngestModule.java
+++ b/FileExtMismatch/src/org/sleuthkit/autopsy/fileextmismatch/FileExtMismatchIngestModule.java
@@ -50,7 +50,7 @@ import org.sleuthkit.datamodel.TskException;
 public class FileExtMismatchIngestModule extends org.sleuthkit.autopsy.ingest.IngestModuleAbstractFile {
     private static FileExtMismatchIngestModule defaultInstance = null;
     private static final Logger logger = Logger.getLogger(FileExtMismatchIngestModule.class.getName());   
-    public static final String MODULE_NAME = "File Extension Mismatch Detection";
+    public static final String MODULE_NAME = "File Extension Mismatch Detector";
     public static final String MODULE_DESCRIPTION = "Flags files that have a non-standard extension based on their file type.";
     public static final String MODULE_VERSION = Version.getVersion();    
 


### PR DESCRIPTION
The context-sensitive enabled/disabled ingest module settings were only written to disk when an ingest was completed, leading to multiple message box reports about missing modules. The settings are now saved whether the user cancels out of the add data source wizard or run ingest modules dialog, the so the warning message will only appear once. This allowed for restoring the name change for the file extension mismatch detector module that was reverted in a previous commit. 
