### PR TITLE
Renamed ingest job settings classes

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/ingest/IngestJobConfigurationPanel.java
+++ b/Core/src/org/sleuthkit/autopsy/ingest/IngestJobConfigurationPanel.java
@@ -58,7 +58,7 @@ class IngestJobConfigurationPanel extends javax.swing.JPanel {
         for (IngestModuleModel module : modules) {
             IngestModuleTemplate moduleTemplate = module.getIngestModuleTemplate();
             if (module.hasModuleSettingsPanel()) {
-                IngestModuleSettings settings = module.getModuleSettingsPanel().getSettings();
+                IngestModuleIngestJobSettings settings = module.getModuleSettingsPanel().getSettings();
                 moduleTemplate.setModuleSettings(settings);
             }
             moduleTemplates.add(moduleTemplate);
@@ -295,7 +295,7 @@ class IngestJobConfigurationPanel extends javax.swing.JPanel {
 
         private final IngestModuleTemplate moduleTemplate;
         private IngestModuleGlobalSetttingsPanel globalSettingsPanel = null;
-        private IngestModuleSettingsPanel moduleSettingsPanel = null;
+        private IngestModuleIngestJobSettingsPanel moduleSettingsPanel = null;
 
         IngestModuleModel(IngestModuleTemplate moduleTemplate) {
             this.moduleTemplate = moduleTemplate;
@@ -331,7 +331,7 @@ class IngestJobConfigurationPanel extends javax.swing.JPanel {
             return moduleTemplate.hasModuleSettingsPanel();
         }
 
-        IngestModuleSettingsPanel getModuleSettingsPanel() {
+        IngestModuleIngestJobSettingsPanel getModuleSettingsPanel() {
             return moduleSettingsPanel;
         }
 

--- a/Core/src/org/sleuthkit/autopsy/ingest/IngestModuleFactory.java
+++ b/Core/src/org/sleuthkit/autopsy/ingest/IngestModuleFactory.java
@@ -117,7 +117,7 @@ public interface IngestModuleFactory {
      *
      * @return The ingest options.
      */
-    IngestModuleSettings getDefaultModuleSettings();
+    IngestModuleIngestJobSettings getDefaultModuleSettings();
 
     /**
      * Queries the factory to determine if it provides user interface panels to
@@ -152,7 +152,7 @@ public interface IngestModuleFactory {
      * @param ingestOptions Per ingest job options to initialize the panel.
      * @return A user interface panel.
      */
-    IngestModuleSettingsPanel getModuleSettingsPanel(IngestModuleSettings settings);
+    IngestModuleIngestJobSettingsPanel getModuleSettingsPanel(IngestModuleIngestJobSettings settings);
 
     /**
      * Queries the factory to determine if it is capable of creating file ingest
@@ -182,7 +182,7 @@ public interface IngestModuleFactory {
      * @param ingestOptions The ingest options for the module instance.
      * @return A data source ingest module instance.
      */
-    DataSourceIngestModule createDataSourceIngestModule(IngestModuleSettings settings);
+    DataSourceIngestModule createDataSourceIngestModule(IngestModuleIngestJobSettings settings);
 
     /**
      * Queries the factory to determine if it is capable of creating file ingest
@@ -212,5 +212,5 @@ public interface IngestModuleFactory {
      * @param ingestOptions The ingest options for the module instance.
      * @return A file ingest module instance.
      */
-    FileIngestModule createFileIngestModule(IngestModuleSettings settings);
+    FileIngestModule createFileIngestModule(IngestModuleIngestJobSettings settings);
 }

--- a/Core/src/org/sleuthkit/autopsy/ingest/IngestModuleFactoryAdapter.java
+++ b/Core/src/org/sleuthkit/autopsy/ingest/IngestModuleFactoryAdapter.java
@@ -44,7 +44,7 @@ public abstract class IngestModuleFactoryAdapter implements IngestModuleFactory 
     }
 
     @Override
-    public IngestModuleSettings getDefaultModuleSettings() {
+    public IngestModuleIngestJobSettings getDefaultModuleSettings() {
         return new NoIngestModuleSettings();
     }
 
@@ -54,7 +54,7 @@ public abstract class IngestModuleFactoryAdapter implements IngestModuleFactory 
     }
 
     @Override
-    public IngestModuleSettingsPanel getModuleSettingsPanel(IngestModuleSettings ingestOptions) {
+    public IngestModuleIngestJobSettingsPanel getModuleSettingsPanel(IngestModuleIngestJobSettings ingestOptions) {
         throw new UnsupportedOperationException();
     }
 
@@ -64,7 +64,7 @@ public abstract class IngestModuleFactoryAdapter implements IngestModuleFactory 
     }
 
     @Override
-    public DataSourceIngestModule createDataSourceIngestModule(IngestModuleSettings ingestOptions) {
+    public DataSourceIngestModule createDataSourceIngestModule(IngestModuleIngestJobSettings ingestOptions) {
         throw new UnsupportedOperationException();
     }
 
@@ -74,7 +74,7 @@ public abstract class IngestModuleFactoryAdapter implements IngestModuleFactory 
     }
 
     @Override
-    public FileIngestModule createFileIngestModule(IngestModuleSettings ingestOptions) {
+    public FileIngestModule createFileIngestModule(IngestModuleIngestJobSettings ingestOptions) {
         throw new UnsupportedOperationException();
     }
 }

--- a/Core/src/org/sleuthkit/autopsy/ingest/IngestModuleIngestJobSettings.java
+++ b/Core/src/org/sleuthkit/autopsy/ingest/IngestModuleIngestJobSettings.java
@@ -21,9 +21,9 @@ package org.sleuthkit.autopsy.ingest;
 import java.io.Serializable;
 
 /**
- * Interface for per ingest job options for ingest modules. Options are
- * serializable to support persistence of options between invocations of the
- * application.
+ * Interface for per ingest job settings for ingest modules. The settings are
+ * serializable to support persistence of settings for different contexts and
+ * between invocations of the application.
  */
-public interface IngestModuleSettings extends Serializable {
+public interface IngestModuleIngestJobSettings extends Serializable {
 }

--- a/Core/src/org/sleuthkit/autopsy/ingest/IngestModuleIngestJobSettingsPanel.java
+++ b/Core/src/org/sleuthkit/autopsy/ingest/IngestModuleIngestJobSettingsPanel.java
@@ -21,14 +21,15 @@ package org.sleuthkit.autopsy.ingest;
 import javax.swing.JPanel;
 
 /**
- * Abstract base class for ingest module job settings panels.
+ * Abstract base class for panels that allow users to specify per ingest job
+ * settings for ingest modules.
  */
-public abstract class IngestModuleSettingsPanel extends JPanel {
+public abstract class IngestModuleIngestJobSettingsPanel extends JPanel {
 
     /**
      * Gets the ingest job settings for an ingest module.
      *
      * @return The ingest settings.
      */
-    public abstract IngestModuleSettings getSettings();
+    public abstract IngestModuleIngestJobSettings getSettings();
 }

--- a/Core/src/org/sleuthkit/autopsy/ingest/IngestModuleTemplate.java
+++ b/Core/src/org/sleuthkit/autopsy/ingest/IngestModuleTemplate.java
@@ -25,10 +25,10 @@ package org.sleuthkit.autopsy.ingest;
 final class IngestModuleTemplate {
 
     private final IngestModuleFactory moduleFactory;
-    private IngestModuleSettings settings = null;
+    private IngestModuleIngestJobSettings settings = null;
     private boolean enabled = true;
 
-    IngestModuleTemplate(IngestModuleFactory moduleFactory, IngestModuleSettings settings) {
+    IngestModuleTemplate(IngestModuleFactory moduleFactory, IngestModuleIngestJobSettings settings) {
         this.moduleFactory = moduleFactory;
         this.settings = settings;
     }
@@ -41,11 +41,11 @@ final class IngestModuleTemplate {
         return moduleFactory.getModuleDescription();
     }
 
-    IngestModuleSettings getModuleSettings() {
+    IngestModuleIngestJobSettings getModuleSettings() {
         return settings;
     }
 
-    void setModuleSettings(IngestModuleSettings settings) {
+    void setModuleSettings(IngestModuleIngestJobSettings settings) {
         this.settings = settings;
     }
         
@@ -53,7 +53,7 @@ final class IngestModuleTemplate {
         return moduleFactory.hasModuleSettingsPanel();
     }
 
-    IngestModuleSettingsPanel getModuleSettingsPanel() {
+    IngestModuleIngestJobSettingsPanel getModuleSettingsPanel() {
         return moduleFactory.getModuleSettingsPanel(settings);
     }
 

--- a/Core/src/org/sleuthkit/autopsy/ingest/NoIngestModuleSettings.java
+++ b/Core/src/org/sleuthkit/autopsy/ingest/NoIngestModuleSettings.java
@@ -22,7 +22,7 @@ package org.sleuthkit.autopsy.ingest;
  * Implementation of the IngestModuleOptions interface for use by ingest modules
  * that do not have per ingest job options.
  */
-public final class NoIngestModuleSettings implements IngestModuleSettings {
+public final class NoIngestModuleSettings implements IngestModuleIngestJobSettings {
 
     private final String setting = "None";
 

--- a/ExifParser/src/org/sleuthkit/autopsy/exifparser/ExifParserModuleFactory.java
+++ b/ExifParser/src/org/sleuthkit/autopsy/exifparser/ExifParserModuleFactory.java
@@ -23,7 +23,7 @@ import org.sleuthkit.autopsy.coreutils.Version;
 import org.sleuthkit.autopsy.ingest.IngestModuleFactoryAdapter;
 import org.sleuthkit.autopsy.ingest.FileIngestModule;
 import org.sleuthkit.autopsy.ingest.IngestModuleFactory;
-import org.sleuthkit.autopsy.ingest.IngestModuleSettings;
+import org.sleuthkit.autopsy.ingest.IngestModuleIngestJobSettings;
 import org.openide.util.NbBundle;
 
 /**
@@ -60,7 +60,7 @@ public class ExifParserModuleFactory extends IngestModuleFactoryAdapter {
     }
 
     @Override
-    public FileIngestModule createFileIngestModule(IngestModuleSettings ingestOptions) {
+    public FileIngestModule createFileIngestModule(IngestModuleIngestJobSettings ingestOptions) {
         return new ExifParserFileIngestModule();
     }
 }

--- a/FileExtMismatch/src/org/sleuthkit/autopsy/fileextmismatch/FileExtMismatchDetectorModuleFactory.java
+++ b/FileExtMismatch/src/org/sleuthkit/autopsy/fileextmismatch/FileExtMismatchDetectorModuleFactory.java
@@ -24,8 +24,8 @@ import org.sleuthkit.autopsy.coreutils.Version;
 import org.sleuthkit.autopsy.ingest.IngestModuleFactoryAdapter;
 import org.sleuthkit.autopsy.ingest.FileIngestModule;
 import org.sleuthkit.autopsy.ingest.IngestModuleFactory;
-import org.sleuthkit.autopsy.ingest.IngestModuleSettings;
-import org.sleuthkit.autopsy.ingest.IngestModuleSettingsPanel;
+import org.sleuthkit.autopsy.ingest.IngestModuleIngestJobSettings;
+import org.sleuthkit.autopsy.ingest.IngestModuleIngestJobSettingsPanel;
 import org.sleuthkit.autopsy.ingest.IngestModuleGlobalSetttingsPanel;
 
 /**
@@ -57,7 +57,7 @@ public class FileExtMismatchDetectorModuleFactory extends IngestModuleFactoryAda
     }
 
     @Override
-    public IngestModuleSettings getDefaultModuleSettings() {
+    public IngestModuleIngestJobSettings getDefaultModuleSettings() {
         return new FileExtMismatchDetectorModuleSettings();
     }
 
@@ -67,7 +67,7 @@ public class FileExtMismatchDetectorModuleFactory extends IngestModuleFactoryAda
     }
 
     @Override
-    public IngestModuleSettingsPanel getModuleSettingsPanel(IngestModuleSettings settings) {
+    public IngestModuleIngestJobSettingsPanel getModuleSettingsPanel(IngestModuleIngestJobSettings settings) {
         assert settings instanceof FileExtMismatchDetectorModuleSettings;
         if (!(settings instanceof FileExtMismatchDetectorModuleSettings)) {
             throw new IllegalArgumentException("Expected settings argument to be instanceof FileExtMismatchDetectorModuleSettings");
@@ -94,7 +94,7 @@ public class FileExtMismatchDetectorModuleFactory extends IngestModuleFactoryAda
     }
 
     @Override
-    public FileIngestModule createFileIngestModule(IngestModuleSettings settings) {
+    public FileIngestModule createFileIngestModule(IngestModuleIngestJobSettings settings) {
         assert settings instanceof FileExtMismatchDetectorModuleSettings;
         if (!(settings instanceof FileExtMismatchDetectorModuleSettings)) {
             throw new IllegalArgumentException("Expected settings argument to be instanceof FileExtMismatchDetectorModuleSettings");

--- a/FileExtMismatch/src/org/sleuthkit/autopsy/fileextmismatch/FileExtMismatchDetectorModuleSettings.java
+++ b/FileExtMismatch/src/org/sleuthkit/autopsy/fileextmismatch/FileExtMismatchDetectorModuleSettings.java
@@ -18,12 +18,12 @@
  */
 package org.sleuthkit.autopsy.fileextmismatch;
 
-import org.sleuthkit.autopsy.ingest.IngestModuleSettings;
+import org.sleuthkit.autopsy.ingest.IngestModuleIngestJobSettings;
 
 /**
  * Ingest options for the file extension mismatch detector ingest module.
  */
-final class FileExtMismatchDetectorModuleSettings implements IngestModuleSettings {
+final class FileExtMismatchDetectorModuleSettings implements IngestModuleIngestJobSettings {
 
     private boolean skipKnownFiles = false;
     private boolean skipFilesWithNoExtension = true;

--- a/FileExtMismatch/src/org/sleuthkit/autopsy/fileextmismatch/FileExtMismatchModuleSettingsPanel.java
+++ b/FileExtMismatch/src/org/sleuthkit/autopsy/fileextmismatch/FileExtMismatchModuleSettingsPanel.java
@@ -18,14 +18,14 @@
  */
 package org.sleuthkit.autopsy.fileextmismatch;
 
-import org.sleuthkit.autopsy.ingest.IngestModuleSettings;
-import org.sleuthkit.autopsy.ingest.IngestModuleSettingsPanel;
+import org.sleuthkit.autopsy.ingest.IngestModuleIngestJobSettings;
+import org.sleuthkit.autopsy.ingest.IngestModuleIngestJobSettingsPanel;
 
 /**
  * UI component used to set ingest job options for file extension mismatch
  * detector ingest modules.
  */
-final class FileExtMismatchModuleSettingsPanel extends IngestModuleSettingsPanel {
+final class FileExtMismatchModuleSettingsPanel extends IngestModuleIngestJobSettingsPanel {
 
     private final FileExtMismatchDetectorModuleSettings settings;
 
@@ -42,7 +42,7 @@ final class FileExtMismatchModuleSettingsPanel extends IngestModuleSettingsPanel
     }
 
     @Override
-    public IngestModuleSettings getSettings() {
+    public IngestModuleIngestJobSettings getSettings() {
         return settings;
     }
 

--- a/FileTypeId/src/org/sleuthkit/autopsy/filetypeid/FileTypeIdModuleFactory.java
+++ b/FileTypeId/src/org/sleuthkit/autopsy/filetypeid/FileTypeIdModuleFactory.java
@@ -24,8 +24,8 @@ import org.sleuthkit.autopsy.coreutils.Version;
 import org.sleuthkit.autopsy.ingest.FileIngestModule;
 import org.sleuthkit.autopsy.ingest.IngestModuleFactory;
 import org.sleuthkit.autopsy.ingest.IngestModuleFactoryAdapter;
-import org.sleuthkit.autopsy.ingest.IngestModuleSettings;
-import org.sleuthkit.autopsy.ingest.IngestModuleSettingsPanel;
+import org.sleuthkit.autopsy.ingest.IngestModuleIngestJobSettings;
+import org.sleuthkit.autopsy.ingest.IngestModuleIngestJobSettingsPanel;
 
 /**
  * An factory that creates file ingest modules that determine the types of
@@ -56,7 +56,7 @@ public class FileTypeIdModuleFactory extends IngestModuleFactoryAdapter {
     }
 
     @Override
-    public IngestModuleSettings getDefaultModuleSettings() {
+    public IngestModuleIngestJobSettings getDefaultModuleSettings() {
         return new FileTypeIdModuleSettings();
     }
 
@@ -66,7 +66,7 @@ public class FileTypeIdModuleFactory extends IngestModuleFactoryAdapter {
     }
 
     @Override
-    public IngestModuleSettingsPanel getModuleSettingsPanel(IngestModuleSettings settings) {
+    public IngestModuleIngestJobSettingsPanel getModuleSettingsPanel(IngestModuleIngestJobSettings settings) {
         assert settings instanceof FileTypeIdModuleSettings;
         if (!(settings instanceof FileTypeIdModuleSettings)) {
             throw new IllegalArgumentException("Expected settings argument to be instanceof FileTypeIdModuleSettings");
@@ -80,7 +80,7 @@ public class FileTypeIdModuleFactory extends IngestModuleFactoryAdapter {
     }
 
     @Override
-    public FileIngestModule createFileIngestModule(IngestModuleSettings settings) {
+    public FileIngestModule createFileIngestModule(IngestModuleIngestJobSettings settings) {
         assert settings instanceof FileTypeIdModuleSettings;
         if (!(settings instanceof FileTypeIdModuleSettings)) {
             throw new IllegalArgumentException("Expected settings argument to be instanceof FileTypeIdModuleSettings");

--- a/FileTypeId/src/org/sleuthkit/autopsy/filetypeid/FileTypeIdModuleSettings.java
+++ b/FileTypeId/src/org/sleuthkit/autopsy/filetypeid/FileTypeIdModuleSettings.java
@@ -18,12 +18,12 @@
  */
 package org.sleuthkit.autopsy.filetypeid;
 
-import org.sleuthkit.autopsy.ingest.IngestModuleSettings;
+import org.sleuthkit.autopsy.ingest.IngestModuleIngestJobSettings;
 
 /**
  * Ingest job options for the file type identifier ingest module instances.
  */
-public class FileTypeIdModuleSettings implements IngestModuleSettings {
+public class FileTypeIdModuleSettings implements IngestModuleIngestJobSettings {
 
     private boolean skipKnownFiles = true;
 

--- a/FileTypeId/src/org/sleuthkit/autopsy/filetypeid/FileTypeIdModuleSettingsPanel.java
+++ b/FileTypeId/src/org/sleuthkit/autopsy/filetypeid/FileTypeIdModuleSettingsPanel.java
@@ -18,14 +18,14 @@
  */
 package org.sleuthkit.autopsy.filetypeid;
 
-import org.sleuthkit.autopsy.ingest.IngestModuleSettings;
-import org.sleuthkit.autopsy.ingest.IngestModuleSettingsPanel;
+import org.sleuthkit.autopsy.ingest.IngestModuleIngestJobSettings;
+import org.sleuthkit.autopsy.ingest.IngestModuleIngestJobSettingsPanel;
 
 /**
  * UI component used to set ingest job options for file type identifier ingest
  * modules.
  */
-final class FileTypeIdModuleSettingsPanel extends IngestModuleSettingsPanel {
+final class FileTypeIdModuleSettingsPanel extends IngestModuleIngestJobSettingsPanel {
 
     private final FileTypeIdModuleSettings settings;
 
@@ -40,7 +40,7 @@ final class FileTypeIdModuleSettingsPanel extends IngestModuleSettingsPanel {
     }
 
     @Override
-    public IngestModuleSettings getSettings() {
+    public IngestModuleIngestJobSettings getSettings() {
         return settings;
     }
 

--- a/HashDatabase/src/org/sleuthkit/autopsy/hashdatabase/HashLookupModuleFactory.java
+++ b/HashDatabase/src/org/sleuthkit/autopsy/hashdatabase/HashLookupModuleFactory.java
@@ -26,8 +26,8 @@ import org.sleuthkit.autopsy.coreutils.Version;
 import org.sleuthkit.autopsy.ingest.IngestModuleFactoryAdapter;
 import org.sleuthkit.autopsy.ingest.FileIngestModule;
 import org.sleuthkit.autopsy.ingest.IngestModuleFactory;
-import org.sleuthkit.autopsy.ingest.IngestModuleSettings;
-import org.sleuthkit.autopsy.ingest.IngestModuleSettingsPanel;
+import org.sleuthkit.autopsy.ingest.IngestModuleIngestJobSettings;
+import org.sleuthkit.autopsy.ingest.IngestModuleIngestJobSettingsPanel;
 import org.sleuthkit.autopsy.ingest.IngestModuleGlobalSetttingsPanel;
 
 /**
@@ -58,7 +58,7 @@ public class HashLookupModuleFactory extends IngestModuleFactoryAdapter {
     }
 
     @Override
-    public IngestModuleSettings getDefaultModuleSettings() {
+    public IngestModuleIngestJobSettings getDefaultModuleSettings() {
         HashDbManager hashDbManager = HashDbManager.getInstance();
         List<String> enabledHashSets = new ArrayList<>();
         List<HashDbManager.HashDb> knownFileHashSets = hashDbManager.getKnownFileHashSets();
@@ -82,7 +82,7 @@ public class HashLookupModuleFactory extends IngestModuleFactoryAdapter {
     }
 
     @Override
-    public IngestModuleSettingsPanel getModuleSettingsPanel(IngestModuleSettings settings) {
+    public IngestModuleIngestJobSettingsPanel getModuleSettingsPanel(IngestModuleIngestJobSettings settings) {
         if (moduleSettingsPanel == null) {
             moduleSettingsPanel = new HashLookupModuleSettingsPanel();
         }
@@ -108,7 +108,7 @@ public class HashLookupModuleFactory extends IngestModuleFactoryAdapter {
     }
 
     @Override
-    public FileIngestModule createFileIngestModule(IngestModuleSettings settings) {
+    public FileIngestModule createFileIngestModule(IngestModuleIngestJobSettings settings) {
         assert settings instanceof HashLookupModuleSettings;
         if (!(settings instanceof HashLookupModuleSettings)) {
             throw new IllegalArgumentException("Expected settings argument to be instanceof HashLookupModuleSettings");

--- a/HashDatabase/src/org/sleuthkit/autopsy/hashdatabase/HashLookupModuleSettings.java
+++ b/HashDatabase/src/org/sleuthkit/autopsy/hashdatabase/HashLookupModuleSettings.java
@@ -20,12 +20,12 @@ package org.sleuthkit.autopsy.hashdatabase;
 
 import java.util.HashSet;
 import java.util.List;
-import org.sleuthkit.autopsy.ingest.IngestModuleSettings;
+import org.sleuthkit.autopsy.ingest.IngestModuleIngestJobSettings;
 
 /**
  * Settings for a hash lookup file ingest module instance.
  */
-final class HashLookupModuleSettings implements IngestModuleSettings {
+final class HashLookupModuleSettings implements IngestModuleIngestJobSettings {
 
     private final HashSet<String> enabledHashSets = new HashSet<>();
     private boolean shouldCalculateHashes = true;

--- a/HashDatabase/src/org/sleuthkit/autopsy/hashdatabase/HashLookupModuleSettingsPanel.java
+++ b/HashDatabase/src/org/sleuthkit/autopsy/hashdatabase/HashLookupModuleSettingsPanel.java
@@ -33,14 +33,14 @@ import org.sleuthkit.autopsy.coreutils.Logger;
 import org.sleuthkit.autopsy.ingest.IngestManager;
 import org.sleuthkit.datamodel.TskCoreException;
 import org.sleuthkit.autopsy.hashdatabase.HashDbManager.HashDb;
-import org.sleuthkit.autopsy.ingest.IngestModuleSettings;
-import org.sleuthkit.autopsy.ingest.IngestModuleSettingsPanel;
+import org.sleuthkit.autopsy.ingest.IngestModuleIngestJobSettings;
+import org.sleuthkit.autopsy.ingest.IngestModuleIngestJobSettingsPanel;
 
 /**
  * Instances of this class provide a simplified UI for managing the hash sets
  * configuration.
  */
-public class HashLookupModuleSettingsPanel extends IngestModuleSettingsPanel implements PropertyChangeListener  {
+public class HashLookupModuleSettingsPanel extends IngestModuleIngestJobSettingsPanel implements PropertyChangeListener  {
 
     private final HashDbManager hashDbManager = HashDbManager.getInstance();
     private HashDatabasesTableModel knownTableModel;
@@ -88,7 +88,7 @@ public class HashLookupModuleSettingsPanel extends IngestModuleSettingsPanel imp
     }
     
     @Override
-    public IngestModuleSettings getSettings() {
+    public IngestModuleIngestJobSettings getSettings() {
         List<String> enabledHashSets = new ArrayList<>();
         List<HashDbManager.HashDb> knownFileHashSets = hashDbManager.getKnownFileHashSets();
         for (HashDb db : knownFileHashSets) {

--- a/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/KeywordSearchIngestSimplePanel.java
+++ b/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/KeywordSearchIngestSimplePanel.java
@@ -27,14 +27,14 @@ import javax.swing.ListSelectionModel;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableColumn;
 import org.sleuthkit.autopsy.coreutils.StringExtract.StringExtractUnicodeTable.SCRIPT;
-import org.sleuthkit.autopsy.ingest.IngestModuleSettings;
-import org.sleuthkit.autopsy.ingest.IngestModuleSettingsPanel;
+import org.sleuthkit.autopsy.ingest.IngestModuleIngestJobSettings;
+import org.sleuthkit.autopsy.ingest.IngestModuleIngestJobSettingsPanel;
 import org.sleuthkit.autopsy.ingest.NoIngestModuleSettings;
 
 /**
  * Ingest job options panel for the keyword search file ingest module.
  */
-public class KeywordSearchIngestSimplePanel extends IngestModuleSettingsPanel {
+public class KeywordSearchIngestSimplePanel extends IngestModuleIngestJobSettingsPanel {
     
     private final static Logger logger = Logger.getLogger(KeywordSearchIngestSimplePanel.class.getName());
     public static final String PROP_OPTIONS = "Keyword Search_Options";
@@ -72,7 +72,7 @@ public class KeywordSearchIngestSimplePanel extends IngestModuleSettingsPanel {
     }
 
     @Override
-    public IngestModuleSettings getSettings() {
+    public IngestModuleIngestJobSettings getSettings() {
         return new NoIngestModuleSettings();
     }
     

--- a/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/KeywordSearchModuleFactory.java
+++ b/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/KeywordSearchModuleFactory.java
@@ -25,8 +25,8 @@ import org.sleuthkit.autopsy.coreutils.Version;
 import org.sleuthkit.autopsy.ingest.IngestModuleFactoryAdapter;
 import org.sleuthkit.autopsy.ingest.FileIngestModule;
 import org.sleuthkit.autopsy.ingest.IngestModuleFactory;
-import org.sleuthkit.autopsy.ingest.IngestModuleSettings;
-import org.sleuthkit.autopsy.ingest.IngestModuleSettingsPanel;
+import org.sleuthkit.autopsy.ingest.IngestModuleIngestJobSettings;
+import org.sleuthkit.autopsy.ingest.IngestModuleIngestJobSettingsPanel;
 import org.sleuthkit.autopsy.ingest.IngestModuleGlobalSetttingsPanel;
 
 /**
@@ -60,7 +60,7 @@ public class KeywordSearchModuleFactory extends IngestModuleFactoryAdapter {
     }
     
     @Override
-    public IngestModuleSettingsPanel getModuleSettingsPanel(IngestModuleSettings ingestJobOptions) {
+    public IngestModuleIngestJobSettingsPanel getModuleSettingsPanel(IngestModuleIngestJobSettings ingestJobOptions) {
         KeywordSearchIngestSimplePanel ingestOptionsPanel = new KeywordSearchIngestSimplePanel();  
         ingestOptionsPanel.load();
         return ingestOptionsPanel; 
@@ -84,7 +84,7 @@ public class KeywordSearchModuleFactory extends IngestModuleFactoryAdapter {
     }
     
     @Override
-    public FileIngestModule createFileIngestModule(IngestModuleSettings ingestJobOptions) {
+    public FileIngestModule createFileIngestModule(IngestModuleIngestJobSettings ingestJobOptions) {
         return new KeywordSearchIngestModule();
     }
 }

--- a/RecentActivity/src/org/sleuthkit/autopsy/recentactivity/RecentActivityExtracterModuleFactory.java
+++ b/RecentActivity/src/org/sleuthkit/autopsy/recentactivity/RecentActivityExtracterModuleFactory.java
@@ -24,7 +24,7 @@ import org.sleuthkit.autopsy.coreutils.Version;
 import org.sleuthkit.autopsy.ingest.DataSourceIngestModule;
 import org.sleuthkit.autopsy.ingest.IngestModuleFactory;
 import org.sleuthkit.autopsy.ingest.IngestModuleFactoryAdapter;
-import org.sleuthkit.autopsy.ingest.IngestModuleSettings;
+import org.sleuthkit.autopsy.ingest.IngestModuleIngestJobSettings;
 
 /**
  * A factory that creates data source ingest modules that extract recent
@@ -58,7 +58,7 @@ public class RecentActivityExtracterModuleFactory extends IngestModuleFactoryAda
     }
 
     @Override
-    public DataSourceIngestModule createDataSourceIngestModule(IngestModuleSettings ingestJobOptions) {
+    public DataSourceIngestModule createDataSourceIngestModule(IngestModuleIngestJobSettings ingestJobOptions) {
         return new RAImageIngestModule();
     }
 }

--- a/ScalpelCarver/src/org/sleuthkit/autopsy/scalpel/ScalpelCarverModuleFactory.java
+++ b/ScalpelCarver/src/org/sleuthkit/autopsy/scalpel/ScalpelCarverModuleFactory.java
@@ -24,7 +24,7 @@ package org.sleuthkit.autopsy.scalpel;
 import org.sleuthkit.autopsy.coreutils.Version;
 import org.sleuthkit.autopsy.ingest.IngestModuleFactoryAdapter;
 import org.sleuthkit.autopsy.ingest.FileIngestModule;
-import org.sleuthkit.autopsy.ingest.IngestModuleSettings;
+import org.sleuthkit.autopsy.ingest.IngestModuleIngestJobSettings;
 import org.openide.util.NbBundle;
 
 /**
@@ -60,7 +60,7 @@ public class ScalpelCarverModuleFactory extends IngestModuleFactoryAdapter {
     }
 
     @Override
-    public FileIngestModule createFileIngestModule(IngestModuleSettings ingestOptions) {
+    public FileIngestModule createFileIngestModule(IngestModuleIngestJobSettings ingestOptions) {
         return new ScalpelCarverIngestModule();
     }
 }

--- a/SevenZip/src/org/sleuthkit/autopsy/sevenzip/ArchiveFileExtractorModuleFactory.java
+++ b/SevenZip/src/org/sleuthkit/autopsy/sevenzip/ArchiveFileExtractorModuleFactory.java
@@ -24,7 +24,7 @@ import org.sleuthkit.autopsy.coreutils.Version;
 import org.sleuthkit.autopsy.ingest.FileIngestModule;
 import org.sleuthkit.autopsy.ingest.IngestModuleFactory;
 import org.sleuthkit.autopsy.ingest.IngestModuleFactoryAdapter;
-import org.sleuthkit.autopsy.ingest.IngestModuleSettings;
+import org.sleuthkit.autopsy.ingest.IngestModuleIngestJobSettings;
 
 /**
  * A factory for creating archive extractor file ingest modules and the user
@@ -59,7 +59,7 @@ public class ArchiveFileExtractorModuleFactory extends IngestModuleFactoryAdapte
     }
 
     @Override
-    public FileIngestModule createFileIngestModule(IngestModuleSettings ingestOptions) {
+    public FileIngestModule createFileIngestModule(IngestModuleIngestJobSettings ingestOptions) {
         return new SevenZipIngestModule();
     }
 }

--- a/ewfVerify/src/org/sleuthkit/autopsy/ewfverify/EwfVerifierModuleFactory.java
+++ b/ewfVerify/src/org/sleuthkit/autopsy/ewfverify/EwfVerifierModuleFactory.java
@@ -24,7 +24,7 @@ import org.sleuthkit.autopsy.coreutils.Version;
 import org.sleuthkit.autopsy.ingest.IngestModuleFactoryAdapter;
 import org.sleuthkit.autopsy.ingest.DataSourceIngestModule;
 import org.sleuthkit.autopsy.ingest.IngestModuleFactory;
-import org.sleuthkit.autopsy.ingest.IngestModuleSettings;
+import org.sleuthkit.autopsy.ingest.IngestModuleIngestJobSettings;
 
 /**
  * An factory that creates data source ingest modules that verify the integrity
@@ -60,7 +60,7 @@ public class EwfVerifierModuleFactory extends IngestModuleFactoryAdapter {
     }
 
     @Override
-    public DataSourceIngestModule createDataSourceIngestModule(IngestModuleSettings ingestOptions) {
+    public DataSourceIngestModule createDataSourceIngestModule(IngestModuleIngestJobSettings ingestOptions) {
         return new EwfVerifyIngestModule();
     }
 }

--- a/thunderbirdparser/src/org/sleuthkit/autopsy/thunderbirdparser/EmailParserModuleFactory.java
+++ b/thunderbirdparser/src/org/sleuthkit/autopsy/thunderbirdparser/EmailParserModuleFactory.java
@@ -24,7 +24,7 @@ import org.sleuthkit.autopsy.coreutils.Version;
 import org.sleuthkit.autopsy.ingest.FileIngestModule;
 import org.sleuthkit.autopsy.ingest.IngestModuleFactory;
 import org.sleuthkit.autopsy.ingest.IngestModuleFactoryAdapter;
-import org.sleuthkit.autopsy.ingest.IngestModuleSettings;
+import org.sleuthkit.autopsy.ingest.IngestModuleIngestJobSettings;
 
 /**
  * A factory for creating email parser file ingest module instances.
@@ -63,7 +63,7 @@ public class EmailParserModuleFactory extends IngestModuleFactoryAdapter {
     }
 
     @Override
-    public FileIngestModule createFileIngestModule(IngestModuleSettings settings) {
+    public FileIngestModule createFileIngestModule(IngestModuleIngestJobSettings settings) {
         return new ThunderbirdMboxFileIngestModule();
     }
 }


### PR DESCRIPTION
Renamed ingest job settings classes to clarify intent and make them, consistent with global settings class names, thus:

IngetModuleSettings -> IngestModuleIngestJobSettings
IngestModuleSettingsPanel -> IngestModuleIngestJobSettingsPanel

with

IngestModuleGlobalSettingsPanel
