### PR TITLE
Fx file signatures

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/corecomponents/DataContentViewerMedia.java
+++ b/Core/src/org/sleuthkit/autopsy/corecomponents/DataContentViewerMedia.java
@@ -260,10 +260,12 @@ public class DataContentViewerMedia extends javax.swing.JPanel implements DataCo
         }
         return Arrays.asList(exts).contains(ext);
     }
-     private static boolean containsMimeType(Node node, List<String> mimeTypes) {
-         if (mimeTypes.isEmpty()) return true; //GStreamer currently is empty. Signature detection for javafx currently
-         AbstractFile file = node.getLookup().lookup(AbstractFile.class);   
-            try {
+    private static boolean containsMimeType(Node node, List<String> mimeTypes) {
+        if (mimeTypes.isEmpty()) {
+            return true; //GStreamer currently is empty. Signature detection for javafx currently
+        }
+        AbstractFile file = node.getLookup().lookup(AbstractFile.class);
+        try {
             ArrayList<BlackboardAttribute> genInfoAttributes = file.getGenInfoAttributes(BlackboardAttribute.ATTRIBUTE_TYPE.TSK_FILE_TYPE_SIG);
             if (genInfoAttributes.isEmpty() == false) {
                 for (BlackboardAttribute batt : genInfoAttributes) {
@@ -276,6 +278,6 @@ public class DataContentViewerMedia extends javax.swing.JPanel implements DataCo
         } catch (TskCoreException ex) {
             return false;
         }
-         return false;
-     }
+        return false;
+    }
 }

--- a/Core/src/org/sleuthkit/autopsy/corecomponents/FXVideoPanel.java
+++ b/Core/src/org/sleuthkit/autopsy/corecomponents/FXVideoPanel.java
@@ -803,7 +803,7 @@ public class FXVideoPanel extends MediaViewVideoPanel {
     }
   
     @Override
-    public List<String> getMimeTypes(){
+    public List<String> getMimeTypes() {
         return supportedMimes;
     }
 }

--- a/Core/src/org/sleuthkit/autopsy/corecomponents/GstVideoPanel.java
+++ b/Core/src/org/sleuthkit/autopsy/corecomponents/GstVideoPanel.java
@@ -803,9 +803,9 @@ public class GstVideoPanel extends MediaViewVideoPanel {
     public String[] getExtensions() {
         return EXTENSIONS;
     }
-    
+
     @Override
-    public List<String> getMimeTypes(){
+    public List<String> getMimeTypes() {
         return supportedMimes;
     }
 }

--- a/Core/src/org/sleuthkit/autopsy/corecomponents/MediaViewVideoPanel.java
+++ b/Core/src/org/sleuthkit/autopsy/corecomponents/MediaViewVideoPanel.java
@@ -109,7 +109,7 @@ public abstract class MediaViewVideoPanel extends JPanel implements FrameCapture
      * Return the extensions supported by this video panel.
      */
     abstract public String[] getExtensions();
-        /**
+    /**
      * Return the MimeTypes supported by this video panel.
      */
     abstract public List<String> getMimeTypes();


### PR DESCRIPTION
added a check for Mimetypes in addition to the existing check for extensions when considering if a video file is supported by javafx 64 bit or not.
