### PR TITLE
Restored synchronization of IngestManager.isIngestRunning()

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/ingest/IngestManager.java
+++ b/Core/src/org/sleuthkit/autopsy/ingest/IngestManager.java
@@ -122,7 +122,7 @@ public class IngestManager {
      *
      * @return True if any ingest jobs are in progress, false otherwise
      */
-    public boolean isIngestRunning() {
+    public synchronized boolean isIngestRunning() {
         return (ingestJobs.isEmpty() == false);
     }
 


### PR DESCRIPTION
The synchronization of this was removed with the notion that the answer to the question isIngestRunning() did not need to be 100% accurate. This appears to have been a mistake that is adversely affecting the reporting modules.
