### PR TITLE
Localization of Autopsy auto update notification bubble

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/core/Bundle_ja.properties
+++ b/Core/src/org/sleuthkit/autopsy/core/Bundle_ja.properties
@@ -8,7 +8,7 @@ OpenIDE-Module-Long-Description=\
     \u8A73\u7D30\u306F\u4E0B\u8A18\u3092\u3054\u89A7\u4E0B\u3055\u3044\u3002http\://www.sleuthkit.org/autopsy/
 OpenIDE-Module-Name=Autopsy-\u30B3\u30A2
 OpenIDE-Module-Short-Description=Autopsy\u30B3\u30A2\u30E2\u30B8\u30E5\u30FC\u30EB
-org_sleuthkit_autopsy_core_update_center=http\://sleuthkit.org/autopsy/updates.xml
+org_sleuthkit_autopsy_core_update_center=http\://sleuthkit.org/autopsy/updates_ja.xml
 Services/AutoupdateType/org_sleuthkit_autopsy_core_update_center.settings=Autopsy\u30A2\u30C3\u30D7\u30C7\u30FC\u30C8\u30BB\u30F3\u30BF\u30FC
 Installer.errorInitJavafx.msg=JavaFX\u521D\u671F\u5316\u30A8\u30E9\u30FC
 Installer.errorInitJavafx.details=\u4E00\u90E8\u306E\u6A5F\u80FD\u304C\u4F7F\u7528\u3067\u304D\u307E\u305B\u3093\u3002\u6B63\u3057\u3044JRE\u304C\u30A4\u30F3\u30B9\u30C8\u30FC\u30EB\u3055\u308C\u3066\u3044\u308B\u306E\u3092\u78BA\u8A8D\u3057\u3066\u4E0B\u3055\u3044\u3002\uFF08Oracle JRE > 1.7.10\uFF09

--- a/Core/updates_ja.xml
+++ b/Core/updates_ja.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE module_updates PUBLIC "-//NetBeans//DTD Autoupdate Catalog 2.5//EN" "http://www.netbeans.org/dtds/autoupdate-catalog-2_7.dtd">
+<module_updates timestamp="00/00/00/04/10/2014">
+	<!--<notification url="http://sleuthkit.org/autopsy/"> Not using URL because it then uses the internal browser, which can't download -->
+	<notification>
+		Autopsy バージョン 3.0.10 は下記からダウンロードできます。http://www.sleuthkit.org/autopsy/.
+	</notification>
+</module_updates>
+
+<!-- Steps to update: 
+  1. Update timestamp so that clients will read the rest of the file.
+     - timestamp seems to be: SEC/MIN/HOUR/DAY/MON/YEAR
+  2. Update message
+
+  See this page for details https://platform.netbeans.org/articles/update-descriptor-specification.html
+-->


### PR DESCRIPTION
While the file updates_ja.xml does not need to exist within the Autopsy source repo, I thought that adding it to the root of the Core directory along side the autopsy-update.xml seems like a logical place to store it.

As I stated in my commit log...

The file updates_ja.xml needs to be placed on the Autopsy web server next to http://sleuthkit.org/autopsy/updates.xml and should be accessible at http://sleuthkit.org/autopsy/updates_ja.xml. This file should be updated anytime that updates.xml is updated. Or more specifically, any time you want a user running with the JA locale to be notified of a software update. While the developers may not be able to read the Japanese text in the updates_ja.xml when they want to make changes, they can at least read the Autopsy version number and simply update that in most cases. If the whole notification message needs to be changed, we will have to manually translate that new version of the message.

According to the netbeans docs, there is no way to localize a notification message. They only allow localization of the module name and description, which exists at the root of the module environment. So, my way around that was to rely on the localization of the URL to download the proper .xml file. When a user has the JA locale set, they will get the URL for the updates_ja.xml instead of the updates.xml.
