### PR TITLE
Test fix for localized text displaying as squares

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/casemodule/CueBannerPanel.java
+++ b/Core/src/org/sleuthkit/autopsy/casemodule/CueBannerPanel.java
@@ -103,11 +103,13 @@ public class CueBannerPanel extends javax.swing.JPanel {
             }
         });
 
-        createNewLabel.setFont(new java.awt.Font("Tahoma", 0, 13)); // NOI18N NON-NLS
+//        createNewLabel.setFont(new java.awt.Font("Tahoma", 0, 13)); // NOI18N NON-NLS
         createNewLabel.setText(org.openide.util.NbBundle.getMessage(CueBannerPanel.class, "CueBannerPanel.createNewLabel.text")); // NOI18N
+        createNewLabel.setFont(createNewLabel.getFont().deriveFont(13.0f));
 
-        openRecentLabel.setFont(new java.awt.Font("Tahoma", 0, 13)); // NOI18N NON-NLS
+//        openRecentLabel.setFont(new java.awt.Font("Tahoma", 0, 13)); // NOI18N NON-NLS
         openRecentLabel.setText(org.openide.util.NbBundle.getMessage(CueBannerPanel.class, "CueBannerPanel.openRecentLabel.text")); // NOI18N
+        openRecentLabel.setFont(openRecentLabel.getFont().deriveFont(13.0f));
 
         openCaseButton.setIcon(new javax.swing.ImageIcon(getClass().getResource("/org/sleuthkit/autopsy/casemodule/btn_icon_open_existing.png"))); // NOI18N NON-NLS
         openCaseButton.setText(org.openide.util.NbBundle.getMessage(CueBannerPanel.class, "CueBannerPanel.openCaseButton.text")); // NOI18N
@@ -122,8 +124,9 @@ public class CueBannerPanel extends javax.swing.JPanel {
             }
         });
 
-        openLabel.setFont(new java.awt.Font("Tahoma", 0, 13)); // NOI18N NON-NLS
+//        openLabel.setFont(new java.awt.Font("Tahoma", 0, 13)); // NOI18N NON-NLS
         openLabel.setText(org.openide.util.NbBundle.getMessage(CueBannerPanel.class, "CueBannerPanel.openLabel.text")); // NOI18N
+        openLabel.setFont(openLabel.getFont().deriveFont(13.0f));
 
         javax.swing.GroupLayout editorPanelLayout = new javax.swing.GroupLayout(editorPanel);
         editorPanel.setLayout(editorPanelLayout);


### PR DESCRIPTION
I think the problem with the localized strings displaying as a series of squares is related to explicit Font declarations in a few places in the code. I made changes to the font declarations in one class as a test case. Instead of changing the font type and font size, I'm retrieving the default font type and changing the size.

Since, I cannot get Autopsy to build right now, can you please test this code and send me a link to an x64 .msi for the current develop branch with this change included? I'll install that .msi and verify that my change works.
