### PR TITLE
Adjusted content viewer fonts

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/contentviewers/Utilities.java
+++ b/Core/src/org/sleuthkit/autopsy/contentviewers/Utilities.java
@@ -40,11 +40,11 @@ public class Utilities {
          * method that sets consistent styles for all viewers and takes font
          * size as an argument.
          */
-        styleSheet.addRule("body {font-family:Arial;font-size:14pt;}"); //NON-NLS
-        styleSheet.addRule("p {font-family:Arial;font-size:14pt;}"); //NON-NLS
-        styleSheet.addRule("li {font-family:Arial;font-size:14pt;}"); //NON-NLS
-        styleSheet.addRule("td {font-family:Arial;font-size:14pt;overflow:hidden;padding-right:5px;padding-left:5px;}"); //NON-NLS
-        styleSheet.addRule("th {font-family:Arial;font-size:14pt;overflow:hidden;padding-right:5px;padding-left:5px;font-weight:bold;}"); //NON-NLS
-        styleSheet.addRule("p {font-family:Arial;font-size:14pt;}"); //NON-NLS
+        styleSheet.addRule("body {font-family:Arial, 'ヒラギノ角ゴ Pro W3','Hiragino Kaku Gothic Pro','メイリオ',Meiryo,'ＭＳ Ｐゴシック','MS PGothic',sans-serif;font-size:14pt;}"); //NON-NLS
+        styleSheet.addRule("p {font-family:Arial, 'ヒラギノ角ゴ Pro W3','Hiragino Kaku Gothic Pro','メイリオ',Meiryo,'ＭＳ Ｐゴシック','MS PGothic',sans-serif;font-size:14pt;}"); //NON-NLS
+        styleSheet.addRule("li {font-family:Arial, 'ヒラギノ角ゴ Pro W3','Hiragino Kaku Gothic Pro','メイリオ',Meiryo,'ＭＳ Ｐゴシック','MS PGothic',sans-serif;font-size:14pt;}"); //NON-NLS
+        styleSheet.addRule("td {font-family:Arial, 'ヒラギノ角ゴ Pro W3','Hiragino Kaku Gothic Pro','メイリオ',Meiryo,'ＭＳ Ｐゴシック','MS PGothic',sans-serif;font-size:14pt;overflow:hidden;padding-right:5px;padding-left:5px;}"); //NON-NLS
+        styleSheet.addRule("th {font-family:Arial, 'ヒラギノ角ゴ Pro W3','Hiragino Kaku Gothic Pro','メイリオ',Meiryo,'ＭＳ Ｐゴシック','MS PGothic',sans-serif;font-size:14pt;overflow:hidden;padding-right:5px;padding-left:5px;font-weight:bold;}"); //NON-NLS
+        styleSheet.addRule("p {font-family:Arial, 'ヒラギノ角ゴ Pro W3','Hiragino Kaku Gothic Pro','メイリオ',Meiryo,'ＭＳ Ｐゴシック','MS PGothic',sans-serif;font-size:14pt;}"); //NON-NLS
     }
 }

--- a/Core/src/org/sleuthkit/autopsy/corecomponents/DataContentViewerArtifact.java
+++ b/Core/src/org/sleuthkit/autopsy/corecomponents/DataContentViewerArtifact.java
@@ -105,7 +105,6 @@ public class DataContentViewerArtifact extends javax.swing.JPanel implements Dat
             jPanel1.setPreferredSize(new java.awt.Dimension(622, 424));
 
             outputViewPane.setEditable(false);
-            outputViewPane.setFont(outputViewPane.getFont().deriveFont(Font.PLAIN, 11));
             outputViewPane.setPreferredSize(new java.awt.Dimension(700, 400));
             jScrollPane1.setViewportView(outputViewPane);
 

--- a/Core/src/org/sleuthkit/autopsy/corecomponents/DataContentViewerHex.java
+++ b/Core/src/org/sleuthkit/autopsy/corecomponents/DataContentViewerHex.java
@@ -113,7 +113,7 @@ public class DataContentViewerHex extends javax.swing.JPanel implements DataCont
         jScrollPane1.setBackground(new java.awt.Color(255, 255, 255));
 
         outputViewPane.setEditable(false);
-        outputViewPane.setFont(outputViewPane.getFont().deriveFont(Font.PLAIN, 11));
+        outputViewPane.setFont(new Font("Courier New", Font.PLAIN, 11)); // NOI18N NON-NLS
         outputViewPane.setMinimumSize(new java.awt.Dimension(700, 20));
         outputViewPane.setPreferredSize(new java.awt.Dimension(700, 400));
         jScrollPane1.setViewportView(outputViewPane);

--- a/Core/src/org/sleuthkit/autopsy/corecomponents/DataContentViewerString.java
+++ b/Core/src/org/sleuthkit/autopsy/corecomponents/DataContentViewerString.java
@@ -129,7 +129,7 @@ public class DataContentViewerString extends javax.swing.JPanel implements DataC
         jPanel1.setPreferredSize(new java.awt.Dimension(502, 424));
 
         outputViewPane.setEditable(false);
-        outputViewPane.setFont(outputViewPane.getFont().deriveFont(Font.PLAIN, 11));
+        outputViewPane.setFont(new Font("monospaced", Font.PLAIN, 11)); // NOI18N NON-NLS
         outputViewPane.setPreferredSize(new java.awt.Dimension(700, 400));
         jScrollPane1.setViewportView(outputViewPane);
 


### PR DESCRIPTION
Changed Text content viewer content to be Courier New font since it will only be ASCII.
Changed Strings content viewer content to be Monospaced, so it can handle Unicode JA strings.
Changed the HTML CSS utility to include JA fonts after Arial. These are used by the Metadata, Results and Text content viewers.
Removed the Java font definition from the Results content viewer since it was not being used by the content.
