### PR TITLE
pass AbstractFile as part of FILE_DONE event

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/ingest/FileIngestPipeline.java
+++ b/Core/src/org/sleuthkit/autopsy/ingest/FileIngestPipeline.java
@@ -19,9 +19,7 @@
 package org.sleuthkit.autopsy.ingest;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import org.sleuthkit.datamodel.AbstractFile;
 
 /**
@@ -112,7 +110,7 @@ final class FileIngestPipeline {
         }
         file.close();
         if (!context.isJobCancelled()) {
-            IngestManager.getInstance().fireFileIngestDone(file.getId());
+            IngestManager.getInstance().fireFileIngestDone(file);
         }
         ingestManager.setIngestTaskProgressCompleted(task);
         return errors;

--- a/Core/src/org/sleuthkit/autopsy/ingest/IngestManager.java
+++ b/Core/src/org/sleuthkit/autopsy/ingest/IngestManager.java
@@ -31,17 +31,17 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
-import org.openide.util.NbBundle;
-import org.sleuthkit.autopsy.coreutils.Logger;
+import javax.swing.JOptionPane;
 import org.netbeans.api.progress.ProgressHandle;
 import org.netbeans.api.progress.ProgressHandleFactory;
 import org.openide.util.Cancellable;
-import org.sleuthkit.autopsy.coreutils.MessageNotifyUtil;
-import org.sleuthkit.datamodel.Content;
-import javax.swing.JOptionPane;
+import org.openide.util.NbBundle;
 import org.sleuthkit.autopsy.casemodule.Case;
 import org.sleuthkit.autopsy.core.UserPreferences;
+import org.sleuthkit.autopsy.coreutils.Logger;
+import org.sleuthkit.autopsy.coreutils.MessageNotifyUtil;
 import org.sleuthkit.datamodel.AbstractFile;
+import org.sleuthkit.datamodel.Content;
 
 /**
  * Manages the execution of ingest jobs.
@@ -288,7 +288,7 @@ public class IngestManager {
         /**
          * Property change event fired when the ingest of a file is completed.
          * The old value of the PropertyChangeEvent is the Autopsy object ID of
-         * the file, and the new value is set to null.
+         * the file. The new value is null or an AbstractFile for that ID.
          */
         FILE_DONE,
     };
@@ -387,6 +387,15 @@ public class IngestManager {
      */
     void fireFileIngestDone(long fileId) {
         fireIngestEventsThreadPool.submit(new FireIngestEventTask(ingestModuleEventPublisher, IngestModuleEvent.FILE_DONE, fileId, null));
+    }
+
+    /**
+     * Fire an ingest event signifying the ingest of a file is completed.
+     *
+     * @param file The file that is completed.
+     */
+    void fireFileIngestDone(AbstractFile file) {
+        fireIngestEventsThreadPool.submit(new FireIngestEventTask(ingestModuleEventPublisher, IngestModuleEvent.FILE_DONE, file.getId(), file));
     }
 
     /**


### PR DESCRIPTION
Rather than just passing the file id in the FILE_DONE event, pass to AbstractFile so listeners don't have to go to the db redundantly.  

I left in the old method that only pass the file id, but to my knowledge it is not used anywhere. Shoul it  be removed?
