### PR TITLE
fixed datetime parsing in wwf analyzer

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/modules/android/WWFMessageAnalyzer.java
+++ b/Core/src/org/sleuthkit/autopsy/modules/android/WWFMessageAnalyzer.java
@@ -88,7 +88,6 @@ class WWFMessageAnalyzer {
 
             while (resultSet.next()) {
                 message = resultSet.getString("message");
-//                new SimpleDateFormat("yyyy-MM-ddTHH:mm:ss z").
                 Long created_at = resultSet.getLong("datetime");
                 user_id = resultSet.getString("user_id");
                 game_id = resultSet.getString("game_id");


### PR DESCRIPTION
As long as the created_at column in the wwf database  is always in iso format and not unix epoch the trivial fix is to use strftime in the sqlite query.
