### PR TITLE
fix usage of read status attribute

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/timeline/events/type/ArtifactEventType.java
+++ b/Core/src/org/sleuthkit/autopsy/timeline/events/type/ArtifactEventType.java
@@ -169,7 +169,7 @@ public interface ArtifactEventType extends EventType {
         @Override
         public String apply(BlackboardArtifact artf, Map<BlackboardAttribute.ATTRIBUTE_TYPE, BlackboardAttribute> attrMap) {
             final BlackboardAttribute attr = attrMap.get(attribute);
-            return (attr != null) ? StringUtils.defaultString(attr.getValueString()) : " ";
+            return (attr != null) ? StringUtils.defaultString(attr.getDisplayString()) : " ";
         }
 
         private final BlackboardAttribute.ATTRIBUTE_TYPE attribute;

--- a/Core/src/org/sleuthkit/autopsy/timeline/events/type/MiscTypes.java
+++ b/Core/src/org/sleuthkit/autopsy/timeline/events/type/MiscTypes.java
@@ -142,14 +142,14 @@ public enum MiscTypes implements EventType, ArtifactEventType {
                      new AttributeExtractor(BlackboardAttribute.ATTRIBUTE_TYPE.TSK_DEVICE_ID));
 
     static public String stringValueOf(BlackboardAttribute attr) {
-        return attr != null ? attr.getValueString() : "";
+        return attr != null ? attr.getDisplayString() : "";
     }
 
     public static String toFrom(BlackboardAttribute dir) {
         if (dir == null) {
             return "";
         } else {
-            switch (dir.getValueString()) {
+            switch (dir.getDisplayString()) {
                 case "Incoming":
                     return "from";
                 case "Outgoing":


### PR DESCRIPTION
I haven't had time to grok this entirely but the new readstatus broke the description generation in timeline.  replacing getStringValue with getDisplayString fixed the obvious symptoms.  I need to look more carefully to see if this fix is exactly right, but it got rid of the exception ( I don't understand the relationship between the cause and the exception ...)

I haven't tested this more than cursorily.
