### PR TITLE
Fix task in progress added 2x bug in ingest task scheduler

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/ingest/IngestTasksScheduler.java
+++ b/Core/src/org/sleuthkit/autopsy/ingest/IngestTasksScheduler.java
@@ -326,7 +326,6 @@ final class IngestTasksScheduler {
             // Try to add the most recently added directory from the 
             // directory tasks queue to the pending file tasks queue. 
             FileIngestTask directoryTask = this.directoryTasks.remove(this.directoryTasks.size() - 1);
-            this.tasksInProgress.remove(directoryTask);
             if (shouldEnqueueFileTask(directoryTask)) {
                 addToPendingFileTasksQueue(directoryTask);
             } else {
@@ -351,9 +350,7 @@ final class IngestTasksScheduler {
                             this.directoryTasks.add(childTask);
                         } else if (shouldEnqueueFileTask(childTask)) {
                             // Found a file, put the task directly into the
-                            // pending file tasks queue. The new task will 
-                            // be put into the tasks in progress list by the
-                            // addToPendingFileTasksQueue() helper.
+                            // pending file tasks queue. 
                             this.tasksInProgress.add(childTask);
                             addToPendingFileTasksQueue(childTask);
                         }
@@ -667,7 +664,7 @@ final class IngestTasksScheduler {
             this.dirQueueSize = countTasksForJob(IngestTasksScheduler.this.directoryTasks, jobId);
             this.fileQueueSize = countTasksForJob(IngestTasksScheduler.this.pendingFileTasks, jobId);
             this.dsQueueSize = countTasksForJob(IngestTasksScheduler.this.pendingDataSourceTasks, jobId);
-            this.runningListSize = countTasksForJob(IngestTasksScheduler.this.tasksInProgress, jobId) - fileQueueSize - dsQueueSize;
+            this.runningListSize = countTasksForJob(IngestTasksScheduler.this.tasksInProgress, jobId);
         }
 
         /**


### PR DESCRIPTION
Removed two remnants of the previous design, one of which caused a task to be added twice to the tasks in progress queue, hanging up ingest.  
