### PR TITLE
Improved performance of job cancellation by moving the code to remove it...

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/ingest/IngestTasksScheduler.java
+++ b/Core/src/org/sleuthkit/autopsy/ingest/IngestTasksScheduler.java
@@ -251,6 +251,7 @@ final class IngestTasksScheduler {
         this.removeTasksForJob(this.directoryTasks, jobId);
         this.removeTasksForJob(this.pendingFileTasks, jobId);
         this.removeTasksForJob(this.pendingDataSourceTasks, jobId);
+        this.removeTasksForJob(this.tasksInProgress, jobId);
         this.shuffleFileTaskQueues();
     }
 
@@ -464,7 +465,6 @@ final class IngestTasksScheduler {
         while (iterator.hasNext()) {
             IngestTask task = iterator.next();
             if (task.getIngestJob().getId() == jobId) {
-                this.tasksInProgress.remove(task);
                 iterator.remove();
             }
         }


### PR DESCRIPTION
...ems from the tasksInProgress list out of the loop that removed elements from the other lists. The tasksInProgress list is not dealt with like all of the other lists.