### PR TITLE
Doxygen user docs

### DIFF
--- a/Core/build.xml
+++ b/Core/build.xml
@@ -8,9 +8,7 @@
     
     
     
-    <target name="javahelp">
-         
-    </target>
+
      
     <!-- Verify that the TSK_HOME env variable is set -->
     <target name="findTSK">

--- a/Core/manifest.mf
+++ b/Core/manifest.mf
@@ -3,7 +3,7 @@ OpenIDE-Module: org.sleuthkit.autopsy.core/10
 OpenIDE-Module-Localizing-Bundle: org/sleuthkit/autopsy/core/Bundle.properties
 OpenIDE-Module-Layer: org/sleuthkit/autopsy/core/layer.xml
 OpenIDE-Module-Implementation-Version: 12
-OpenIDE-Module-Requires: org.openide.windows.WindowManager, org.netbeans.api.javahelp.Help
+OpenIDE-Module-Requires: org.openide.windows.WindowManager
 AutoUpdate-Show-In-Client: true
 AutoUpdate-Essential-Module: true
 OpenIDE-Module-Install: org/sleuthkit/autopsy/core/Installer.class

--- a/Core/nbproject/project.xml
+++ b/Core/nbproject/project.xml
@@ -25,15 +25,6 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.modules.javahelp</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <release-version>1</release-version>
-                        <specification-version>2.27.1</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
                     <code-name-base>org.netbeans.modules.options.api</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/Core/src/org/sleuthkit/autopsy/corecomponents/Bundle.properties
+++ b/Core/src/org/sleuthkit/autopsy/corecomponents/Bundle.properties
@@ -27,6 +27,8 @@ Format_OperatingSystem_Value={0} version {1} running on {2}
 LBL_Copyright=<div style\="font-size\: 12pt; font-family\: Verdana, 'Verdana CE',  Arial, 'Arial CE', 'Lucida Grande CE', lucida, 'Helvetica CE', sans-serif; ">Autopsy&trade; is a digital forensics platform based on The Sleuth Kit&trade; and other tools. <br><ul><li>General Information: <a style\="color\: \#1E2A60;" href\="http\://www.sleuthkit.org">http\://www.sleuthkit.org</a>.</li><li>Training: <a style\="color\: \#1E2A60;" href\="http://www.basistech.com/autopsy-training">http://www.basistech.com/autopsy-training</a></li><li>Commercial Support: <a style\="color\: \#1E2A60;" href\="http://www.basistech.com/digital-forensics/autopsy/support/">http://www.basistech.com/digital-forensics/autopsy/support/</a></li></ul>Copyright &copy; 2003-2014. </div>
 URL_ON_IMG=http://www.sleuthkit.org/
 
+URL_ON_HELP=http://sleuthkit.org/autopsy/docs/user-docs/3.1/
+
 LBL_Close=Close
 DataContentViewerString.copyMenuItem.text=Copy
 DataContentViewerHex.copyMenuItem.text=Copy

--- a/Core/src/org/sleuthkit/autopsy/corecomponents/OnlineHelpAction.java
+++ b/Core/src/org/sleuthkit/autopsy/corecomponents/OnlineHelpAction.java
@@ -36,6 +36,7 @@ import org.openide.util.NbBundle.Messages;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 /**
  * Implements a hyperlink to the Online Documentation.
  */
@@ -59,23 +60,23 @@ public final class OnlineHelpAction implements ActionListener {
     @Override
     public void actionPerformed(ActionEvent e) {
         // TODO implement action body                                   
-    try {   
-        uri = new URI(NbBundle.getMessage(OnlineHelpAction.class, "URL_ON_HELP")); // NOI18N
-        viewOnlineHelp();
-    } catch (URISyntaxException ex) {
-        Logger.log(Level.SEVERE, "Unable to load Online Documentation", ex);
+        try {
+            uri = new URI(NbBundle.getMessage(OnlineHelpAction.class, "URL_ON_HELP")); // NOI18N
+            viewOnlineHelp();
+        } catch (URISyntaxException ex) {
+            Logger.log(Level.SEVERE, "Unable to load Online Documentation", ex);
+        }
+        uri = null;
     }
-    uri = null;
-    }
-    
+
     /**
-     * Displays the Online Documentation in the system browser. 
-     * If not available, displays it in the built-in OpenIDE HTML Browser.
+     * Displays the Online Documentation in the system browser. If not
+     * available, displays it in the built-in OpenIDE HTML Browser.
      */
     private void viewOnlineHelp() {
         if (uri != null) {
             // Display URL in the SYstem browser
-            if(Desktop.isDesktopSupported()){
+            if (Desktop.isDesktopSupported()) {
                 Desktop desktop = Desktop.getDesktop();
                 try {
                     desktop.browse(uri);
@@ -83,17 +84,15 @@ public final class OnlineHelpAction implements ActionListener {
                     // TODO Auto-generated catch block
                     Logger.log(Level.SEVERE, "Unable to launch the system browser", ex);
                 }
-            }
-            else {
+            } else {
                 org.openide.awt.StatusDisplayer.getDefault().setStatusText(NbBundle.getMessage(HTMLViewAction.class, "CTL_OpeningBrowser")); //NON-NLS
                 try {
                     HtmlBrowser.URLDisplayer.getDefault().showURL(uri.toURL());
-                }
-                catch(MalformedURLException ex){
+                } catch (MalformedURLException ex) {
                     Logger.log(Level.SEVERE, "Unable to launch the built-in browser", ex);
-                } 
+                }
             }
-         }
+        }
     }
-    
+
 }

--- a/Core/src/org/sleuthkit/autopsy/corecomponents/OnlineHelpAction.java
+++ b/Core/src/org/sleuthkit/autopsy/corecomponents/OnlineHelpAction.java
@@ -20,8 +20,11 @@ package org.sleuthkit.autopsy.corecomponents;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.Desktop;
+import java.io.IOException;
 import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URISyntaxException;
+import java.net.URI;
 import org.netbeans.core.actions.HTMLViewAction;
 import org.openide.awt.ActionID;
 import org.openide.awt.ActionReference;
@@ -33,6 +36,9 @@ import org.openide.util.NbBundle.Messages;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
+/**
+ * Implements a hyperlink to the Online Documentation.
+ */
 @ActionID(
         category = "Help",
         id = "org.sleuthkit.autopsy.corecomponents.OnlineHelpAction"
@@ -47,26 +53,47 @@ import java.util.logging.Logger;
 @Messages("CTL_OnlineHelpAction=Online Documentation")
 public final class OnlineHelpAction implements ActionListener {
 
-    private URL url;
+    private URI uri;
     private static final Logger Logger = org.sleuthkit.autopsy.coreutils.Logger.getLogger(AboutWindowPanel.class.getName());
 
     @Override
     public void actionPerformed(ActionEvent e) {
         // TODO implement action body                                   
     try {   
-        url = new URL(NbBundle.getMessage(OnlineHelpAction.class, "URL_ON_HELP")); // NOI18N
-        showUrl();
-    } catch (MalformedURLException ex) {
-        Logger.log(Level.SEVERE, "Unable to load Online DOcumentation", ex);
+        uri = new URI(NbBundle.getMessage(OnlineHelpAction.class, "URL_ON_HELP")); // NOI18N
+        viewOnlineHelp();
+    } catch (URISyntaxException ex) {
+        Logger.log(Level.SEVERE, "Unable to load Online Documentation", ex);
     }
-    url = null;
+    uri = null;
     }
     
-        private void showUrl() {
-        if (url != null) {
-            org.openide.awt.StatusDisplayer.getDefault().setStatusText(NbBundle.getMessage(HTMLViewAction.class, "CTL_OpeningBrowser")); //NON-NLS
-            HtmlBrowser.URLDisplayer.getDefault().showURL(url);
-        }
+    /**
+     * Displays the Online Documentation in the system browser. 
+     * If not available, displays it in the built-in OpenIDE HTML Browser.
+     */
+    private void viewOnlineHelp() {
+        if (uri != null) {
+            // Display URL in the SYstem browser
+            if(Desktop.isDesktopSupported()){
+                Desktop desktop = Desktop.getDesktop();
+                try {
+                    desktop.browse(uri);
+                } catch (IOException ex) {
+                    // TODO Auto-generated catch block
+                    Logger.log(Level.SEVERE, "Unable to launch the system browser", ex);
+                }
+            }
+            else {
+                org.openide.awt.StatusDisplayer.getDefault().setStatusText(NbBundle.getMessage(HTMLViewAction.class, "CTL_OpeningBrowser")); //NON-NLS
+                try {
+                    HtmlBrowser.URLDisplayer.getDefault().showURL(uri.toURL());
+                }
+                catch(MalformedURLException ex){
+                    Logger.log(Level.SEVERE, "Unable to launch the built-in browser", ex);
+                } 
+            }
+         }
     }
     
 }

--- a/Core/src/org/sleuthkit/autopsy/corecomponents/OnlineHelpAction.java
+++ b/Core/src/org/sleuthkit/autopsy/corecomponents/OnlineHelpAction.java
@@ -1,0 +1,72 @@
+/*
+ * Autopsy Forensic Browser
+ *
+ * Copyright 2011-2014 Basis Technology Corp.
+ * Contact: carrier <at> sleuthkit <dot> org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sleuthkit.autopsy.corecomponents;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.net.MalformedURLException;
+import java.net.URL;
+import org.netbeans.core.actions.HTMLViewAction;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionReference;
+import org.openide.awt.ActionReferences;
+import org.openide.awt.ActionRegistration;
+import org.openide.awt.HtmlBrowser;
+import org.openide.util.NbBundle;
+import org.openide.util.NbBundle.Messages;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+@ActionID(
+        category = "Help",
+        id = "org.sleuthkit.autopsy.corecomponents.OnlineHelpAction"
+)
+@ActionRegistration(
+        displayName = "#CTL_OnlineHelpAction"
+)
+@ActionReferences({
+    @ActionReference(path = "Menu/Help", position = 0),
+    @ActionReference(path = "Shortcuts", name = "F1")
+})
+@Messages("CTL_OnlineHelpAction=Online Documentation")
+public final class OnlineHelpAction implements ActionListener {
+
+    private URL url;
+    private static final Logger Logger = org.sleuthkit.autopsy.coreutils.Logger.getLogger(AboutWindowPanel.class.getName());
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        // TODO implement action body                                   
+    try {   
+        url = new URL(NbBundle.getMessage(OnlineHelpAction.class, "URL_ON_HELP")); // NOI18N
+        showUrl();
+    } catch (MalformedURLException ex) {
+        Logger.log(Level.SEVERE, "Unable to load Online DOcumentation", ex);
+    }
+    url = null;
+    }
+    
+        private void showUrl() {
+        if (url != null) {
+            org.openide.awt.StatusDisplayer.getDefault().setStatusText(NbBundle.getMessage(HTMLViewAction.class, "CTL_OpeningBrowser")); //NON-NLS
+            HtmlBrowser.URLDisplayer.getDefault().showURL(url);
+        }
+    }
+    
+}

--- a/Core/src/org/sleuthkit/autopsy/corecomponents/OnlineHelpAction.java
+++ b/Core/src/org/sleuthkit/autopsy/corecomponents/OnlineHelpAction.java
@@ -60,13 +60,7 @@ public final class OnlineHelpAction implements ActionListener {
     @Override
     public void actionPerformed(ActionEvent e) {
         // TODO implement action body                                   
-        try {
-            uri = new URI(NbBundle.getMessage(OnlineHelpAction.class, "URL_ON_HELP")); // NOI18N
-            viewOnlineHelp();
-        } catch (URISyntaxException ex) {
-            Logger.log(Level.SEVERE, "Unable to load Online Documentation", ex);
-        }
-        uri = null;
+        viewOnlineHelp();
     }
 
     /**
@@ -74,6 +68,11 @@ public final class OnlineHelpAction implements ActionListener {
      * available, displays it in the built-in OpenIDE HTML Browser.
      */
     private void viewOnlineHelp() {
+        try {
+            uri = new URI(NbBundle.getMessage(OnlineHelpAction.class, "URL_ON_HELP"));
+        } catch (URISyntaxException ex) {
+            Logger.log(Level.SEVERE, "Unable to load Online Documentation", ex);
+        }
         if (uri != null) {
             // Display URL in the SYstem browser
             if (Desktop.isDesktopSupported()) {

--- a/KeywordSearch/nbproject/project.xml
+++ b/KeywordSearch/nbproject/project.xml
@@ -16,15 +16,6 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.modules.javahelp</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <release-version>1</release-version>
-                        <specification-version>2.22.1</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
                     <code-name-base>org.netbeans.modules.options.api</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>


### PR DESCRIPTION
1. *Help Content* under *Help* menu removed.
2. It is replaced by *Online Documentation* which links to [Autopsy User Documentation](http://sleuthkit.org/autopsy/docs/user-docs/3.1/)
3. This Online Documentation opens in the system browser by default. If not supported, it opens in the built-in browser.