### PR TITLE
don't call Case.hasData() in OpenTimelineAction so we don't block the ed...

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/timeline/Bundle.properties
+++ b/Core/src/org/sleuthkit/autopsy/timeline/Bundle.properties
@@ -41,5 +41,5 @@ Timeline.ProgressWindow.cancel.confdlg.msg=Do you want to cancel time line creat
 Timeline.ProgressWindow.cancel.confdlg.detail=Cancel timeline creation?
 Timeline.progressWindow.name=Timeline
 Timeline.progressWindow.title=Generating Timeline data
-OpenTimeLineAction.msgdlg.text=Error creating timeline, there are no data sources.
+OpenTimeLineAction.msgdlg.text=Could not create timeline, there are no data sources.
 TimeLineTopComponent.timeZonePanel.text=Display Times In\:

--- a/Core/src/org/sleuthkit/autopsy/timeline/OpenTimelineAction.java
+++ b/Core/src/org/sleuthkit/autopsy/timeline/OpenTimelineAction.java
@@ -54,7 +54,9 @@ public class OpenTimelineAction extends CallableSystemAction {
 
     @Override
     public boolean isEnabled() {
-        return Case.isCaseOpen() && fxInited && Case.getCurrentCase().hasData();
+        /** we disabled the check to hasData() because if it is executed while a
+         * data source is being added, it blocks the edt */
+        return Case.isCaseOpen() && fxInited;// && Case.getCurrentCase().hasData();
     }
 
     @Override
@@ -68,8 +70,8 @@ public class OpenTimelineAction extends CallableSystemAction {
 
         if (currentCase.hasData() == false) {
             JOptionPane.showMessageDialog(WindowManager.getDefault().getMainWindow(),
-                                          NbBundle.getMessage(this.getClass(), "OpenTimeLineAction.msgdlg.text"));
-            LOGGER.log(Level.INFO, "Error creating timeline, there are no data sources.");// NON-NLS
+                    NbBundle.getMessage(this.getClass(), "OpenTimeLineAction.msgdlg.text"));
+            LOGGER.log(Level.INFO, "Could not create timeline, there are no data sources.");// NON-NLS
             return;
         }
         synchronized (OpenTimelineAction.class) {


### PR DESCRIPTION
...t.

I also softened the mesage that pops up if the timeline is opened with no data sources added.