### PR TITLE
Message pops up in case of invalid STIX file/path

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/modules/stix/STIXReportModule.java
+++ b/Core/src/org/sleuthkit/autopsy/modules/stix/STIXReportModule.java
@@ -132,9 +132,7 @@ public class STIXReportModule implements GeneralReportModule {
 
         if (!stixFile.exists()) {
             logger.log(Level.SEVERE, String.format("Unable to open STIX file/directory %s", stixFileName));
-            MessageNotifyUtil.Notify.show("STIXReportModule",
-                    "Unable to open STIX file/directory " + stixFileName,
-                    MessageNotifyUtil.MessageType.ERROR);
+            MessageNotifyUtil.Message.error("Unable to open STIX file/directory" + stixFileName);
             progressPanel.complete();
             progressPanel.updateStatusLabel("Could not open file/directory " + stixFileName);
             return;


### PR DESCRIPTION
Replaced ```Notify.show()``` (which displays error at the bottom right corner) with ```Message.error()``` (pops up with red error sign).