### PR TITLE
Replaced calls to SleuthkitCase.runQuery() with calls to SleuthkitCase.e...

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/datamodel/RecentFilesChildren.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/RecentFilesChildren.java
@@ -29,6 +29,8 @@ import org.sleuthkit.autopsy.coreutils.Logger;
 import org.openide.nodes.ChildFactory;
 import org.openide.nodes.Node;
 import org.sleuthkit.datamodel.SleuthkitCase;
+import org.sleuthkit.datamodel.SleuthkitCase.CaseDbQuery;
+import org.sleuthkit.datamodel.TskCoreException;
 
 /**
  *
@@ -82,21 +84,14 @@ import org.sleuthkit.datamodel.SleuthkitCase;
     @SuppressWarnings("deprecation")
     private long runTimeQuery(String query) {
         long result = 0;
-        ResultSet rs = null;
-        try {
-            rs = skCase.runQuery(query);
-            result = rs.getLong(1);
-        } catch (SQLException ex) {
-            logger.log(Level.WARNING, "Couldn't get recent files results", ex); //NON-NLS
-        } finally {
-            if (rs != null) {
-                try {
-                    skCase.closeRunQuery(rs);
-                } catch (SQLException ex) {
-                    logger.log(Level.WARNING, "Error closing result set after getting recent files results", ex); //NON-NLS
-                }
-            }
+
+        try (CaseDbQuery dbQuery = skCase.executeQuery(query)) {
+            ResultSet resultSet = dbQuery.getResultSet();
+            result = resultSet.getLong(1);
+        } catch (TskCoreException | SQLException ex) {
+            logger.log(Level.WARNING, "Couldn't get recent files results: ", ex); //NON-NLS
         }
+        
         return result;
     }
 }

--- a/Core/src/org/sleuthkit/autopsy/report/ReportGenerator.java
+++ b/Core/src/org/sleuthkit/autopsy/report/ReportGenerator.java
@@ -63,6 +63,7 @@ import org.sleuthkit.datamodel.BlackboardAttribute.ATTRIBUTE_TYPE;
 import org.sleuthkit.datamodel.Content;
 import org.sleuthkit.datamodel.ContentTag;
 import org.sleuthkit.datamodel.SleuthkitCase;
+import org.sleuthkit.datamodel.SleuthkitCase.CaseDbQuery;
 import org.sleuthkit.datamodel.TskCoreException;
 import org.sleuthkit.datamodel.TskData;
 
@@ -888,19 +889,22 @@ import org.sleuthkit.datamodel.TskData;
      */
     @SuppressWarnings("deprecation")
     private void writeKeywordHits(List<TableReportModule> tableModules, String comment, HashSet<String> tagNamesFilter) {
-        ResultSet listsRs = null;
-        try {
-            // Query for keyword lists-only so that we can tell modules what lists
-            // will exist for their index.
-            // @@@ There is a bug in here.  We should use the tags in the below code
-            // so that we only report the lists that we will later provide with real
-            // hits.  If no keyord hits are tagged, then we make the page for nothing.
-            listsRs = skCase.runQuery("SELECT att.value_text AS list " + //NON-NLS
-                                                "FROM blackboard_attributes AS att, blackboard_artifacts AS art " + //NON-NLS
-                                                "WHERE att.attribute_type_id = " + ATTRIBUTE_TYPE.TSK_SET_NAME.getTypeID() + " " + //NON-NLS
-                                                    "AND art.artifact_type_id = " + ARTIFACT_TYPE.TSK_KEYWORD_HIT.getTypeID() + " " + //NON-NLS
-                                                    "AND att.artifact_id = art.artifact_id " +  //NON-NLS
-                                                "GROUP BY list"); //NON-NLS
+        
+        // Query for keyword lists-only so that we can tell modules what lists
+        // will exist for their index.
+        // @@@ There is a bug in here.  We should use the tags in the below code
+        // so that we only report the lists that we will later provide with real
+        // hits.  If no keyord hits are tagged, then we make the page for nothing.
+        String keywordListQuery = 
+                "SELECT att.value_text AS list " + //NON-NLS
+                "FROM blackboard_attributes AS att, blackboard_artifacts AS art " + //NON-NLS
+                "WHERE att.attribute_type_id = " + ATTRIBUTE_TYPE.TSK_SET_NAME.getTypeID() + " " + //NON-NLS
+                "AND art.artifact_type_id = " + ARTIFACT_TYPE.TSK_KEYWORD_HIT.getTypeID() + " " + //NON-NLS
+                "AND att.artifact_id = art.artifact_id " +  //NON-NLS
+                "GROUP BY list"; //NON-NLS
+
+        try (CaseDbQuery dbQuery = skCase.executeQuery(keywordListQuery)) {
+            ResultSet listsRs = dbQuery.getResultSet();
             List<String> lists = new ArrayList<>();
             while(listsRs.next()) {
                 String list = listsRs.getString("list"); //NON-NLS
@@ -919,36 +923,32 @@ import org.sleuthkit.datamodel.TskData;
                                             ARTIFACT_TYPE.TSK_KEYWORD_HIT.getDisplayName()));
             }
         }
-        catch (SQLException ex) {
+        catch (TskCoreException | SQLException ex) {
             errorList.add(NbBundle.getMessage(this.getClass(), "ReportGenerator.errList.failedQueryKWLists"));
-            logger.log(Level.SEVERE, "Failed to query keyword lists.", ex); //NON-NLS
+            logger.log(Level.SEVERE, "Failed to query keyword lists: ", ex); //NON-NLS
             return;
-        } finally {
-            if (listsRs != null) {
-                try {
-                    skCase.closeRunQuery(listsRs);
-                } catch (SQLException ex) {
-                }
-            }
         }
         
-        ResultSet rs = null;
-        try {
-            // Query for keywords, grouped by list
-            rs = skCase.runQuery("SELECT art.artifact_id, art.obj_id, att1.value_text AS keyword, att2.value_text AS preview, att3.value_text AS list, f.name AS name, f.parent_path AS parent_path " + //NON-NLS
-                                           "FROM blackboard_artifacts AS art, blackboard_attributes AS att1, blackboard_attributes AS att2, blackboard_attributes AS att3, tsk_files AS f " + //NON-NLS
-                                           "WHERE (att1.artifact_id = art.artifact_id) " + //NON-NLS
-                                                 "AND (att2.artifact_id = art.artifact_id) " +  //NON-NLS
-                                                 "AND (att3.artifact_id = art.artifact_id) " +  //NON-NLS
-                                                 "AND (f.obj_id = art.obj_id) " + //NON-NLS
-                                                 "AND (att1.attribute_type_id = " + ATTRIBUTE_TYPE.TSK_KEYWORD.getTypeID() + ") " + //NON-NLS
-                                                 "AND (att2.attribute_type_id = " + ATTRIBUTE_TYPE.TSK_KEYWORD_PREVIEW.getTypeID() + ") " + //NON-NLS
-                                                 "AND (att3.attribute_type_id = " + ATTRIBUTE_TYPE.TSK_SET_NAME.getTypeID() + ") " + //NON-NLS
-                                                 "AND (art.artifact_type_id = " + ARTIFACT_TYPE.TSK_KEYWORD_HIT.getTypeID() + ") " + //NON-NLS
-                                           "ORDER BY list, keyword, parent_path, name"); //NON-NLS
+        // Query for keywords, grouped by list
+        String keywordsQuery = 
+                "SELECT art.artifact_id, art.obj_id, att1.value_text AS keyword, att2.value_text AS preview, att3.value_text AS list, f.name AS name, f.parent_path AS parent_path " + //NON-NLS
+                "FROM blackboard_artifacts AS art, blackboard_attributes AS att1, blackboard_attributes AS att2, blackboard_attributes AS att3, tsk_files AS f " + //NON-NLS
+                "WHERE (att1.artifact_id = art.artifact_id) " + //NON-NLS
+                "AND (att2.artifact_id = art.artifact_id) " +  //NON-NLS
+                "AND (att3.artifact_id = art.artifact_id) " +  //NON-NLS
+                "AND (f.obj_id = art.obj_id) " + //NON-NLS
+                "AND (att1.attribute_type_id = " + ATTRIBUTE_TYPE.TSK_KEYWORD.getTypeID() + ") " + //NON-NLS
+                "AND (att2.attribute_type_id = " + ATTRIBUTE_TYPE.TSK_KEYWORD_PREVIEW.getTypeID() + ") " + //NON-NLS
+                "AND (att3.attribute_type_id = " + ATTRIBUTE_TYPE.TSK_SET_NAME.getTypeID() + ") " + //NON-NLS
+                "AND (art.artifact_type_id = " + ARTIFACT_TYPE.TSK_KEYWORD_HIT.getTypeID() + ") " + //NON-NLS
+                "ORDER BY list, keyword, parent_path, name"; //NON-NLS
+        
+        try (CaseDbQuery dbQuery = skCase.executeQuery(keywordsQuery)) {
+            ResultSet resultSet = dbQuery.getResultSet();
+            
             String currentKeyword = "";
             String currentList = "";
-            while (rs.next()) {
+            while (resultSet.next()) {
                 // Check to see if all the TableReportModules have been canceled
                 if (tableModules.isEmpty()) {
                     break;
@@ -962,16 +962,16 @@ import org.sleuthkit.datamodel.TskData;
                 }
  
                 // Get any tags that associated with this artifact and apply the tag filter.
-                HashSet<String> uniqueTagNames = getUniqueTagNames(rs.getLong("artifact_id")); //NON-NLS
+                HashSet<String> uniqueTagNames = getUniqueTagNames(resultSet.getLong("artifact_id")); //NON-NLS
                 if(failsTagFilter(uniqueTagNames, tagNamesFilter)) {
                     continue;
                 }                    
                 String tagsList = makeCommaSeparatedList(uniqueTagNames);
                                                         
-                Long objId = rs.getLong("obj_id"); //NON-NLS
-                String keyword = rs.getString("keyword"); //NON-NLS
-                String preview = rs.getString("preview"); //NON-NLS
-                String list = rs.getString("list"); //NON-NLS
+                Long objId = resultSet.getLong("obj_id"); //NON-NLS
+                String keyword = resultSet.getString("keyword"); //NON-NLS
+                String preview = resultSet.getString("preview"); //NON-NLS
+                String list = resultSet.getString("list"); //NON-NLS
                 String uniquePath = "";
 
                  try {
@@ -1025,16 +1025,9 @@ import org.sleuthkit.datamodel.TskData;
                 tableProgress.get(module).increment();
                 module.endDataType();
             }
-        } catch (SQLException ex) {
+        } catch (TskCoreException | SQLException ex) {
             errorList.add(NbBundle.getMessage(this.getClass(), "ReportGenerator.errList.failedQueryKWs"));
-            logger.log(Level.SEVERE, "Failed to query keywords.", ex); //NON-NLS
-        } finally {
-            if (rs != null) {
-                try {
-                    skCase.closeRunQuery(rs);
-                } catch (SQLException ex) {
-                }
-            }
+            logger.log(Level.SEVERE, "Failed to query keywords: ", ex); //NON-NLS
         }
     }
     
@@ -1044,15 +1037,17 @@ import org.sleuthkit.datamodel.TskData;
      */
     @SuppressWarnings("deprecation")
     private void writeHashsetHits(List<TableReportModule> tableModules,  String comment, HashSet<String> tagNamesFilter) {
-        ResultSet listsRs = null;
-        try {
+        String hashsetsQuery =
+                "SELECT att.value_text AS list " + //NON-NLS
+                "FROM blackboard_attributes AS att, blackboard_artifacts AS art " + //NON-NLS
+                "WHERE att.attribute_type_id = " + ATTRIBUTE_TYPE.TSK_SET_NAME.getTypeID() + " " + //NON-NLS
+                "AND art.artifact_type_id = " + ARTIFACT_TYPE.TSK_HASHSET_HIT.getTypeID() + " " + //NON-NLS
+                "AND att.artifact_id = art.artifact_id " +  //NON-NLS
+                "GROUP BY list"; //NON-NLS
+
+        try (CaseDbQuery dbQuery = skCase.executeQuery(hashsetsQuery)) {
             // Query for hashsets
-            listsRs = skCase.runQuery("SELECT att.value_text AS list " + //NON-NLS
-                                                "FROM blackboard_attributes AS att, blackboard_artifacts AS art " + //NON-NLS
-                                                "WHERE att.attribute_type_id = " + ATTRIBUTE_TYPE.TSK_SET_NAME.getTypeID() + " " + //NON-NLS
-                                                    "AND art.artifact_type_id = " + ARTIFACT_TYPE.TSK_HASHSET_HIT.getTypeID() + " " + //NON-NLS
-                                                    "AND att.artifact_id = art.artifact_id " +  //NON-NLS
-                                                "GROUP BY list"); //NON-NLS
+            ResultSet listsRs = dbQuery.getResultSet();
             List<String> lists = new ArrayList<>();
             while(listsRs.next()) {
                 lists.add(listsRs.getString("list")); //NON-NLS
@@ -1065,31 +1060,26 @@ import org.sleuthkit.datamodel.TskData;
                         NbBundle.getMessage(this.getClass(), "ReportGenerator.progress.processing",
                                             ARTIFACT_TYPE.TSK_HASHSET_HIT.getDisplayName()));
             }
-        } catch (SQLException ex) {     
+        } catch (TskCoreException | SQLException ex) {     
             errorList.add(NbBundle.getMessage(this.getClass(), "ReportGenerator.errList.failedQueryHashsetLists"));
-            logger.log(Level.SEVERE, "Failed to query hashset lists.", ex); //NON-NLS
+            logger.log(Level.SEVERE, "Failed to query hashset lists: ", ex); //NON-NLS
             return;
-        } finally {
-            if (listsRs != null) {
-                try {
-                    skCase.closeRunQuery(listsRs);
-                } catch (SQLException ex) {
-                }
-            }
         }
         
-        ResultSet rs = null;
-        try {
+        String hashsetHitsQuery =
+                "SELECT art.artifact_id, art.obj_id, att.value_text AS setname, f.name AS name, f.size AS size, f.parent_path AS parent_path " + //NON-NLS
+                "FROM blackboard_artifacts AS art, blackboard_attributes AS att, tsk_files AS f " + //NON-NLS
+                "WHERE (att.artifact_id = art.artifact_id) " + //NON-NLS
+                "AND (f.obj_id = art.obj_id) " + //NON-NLS
+                "AND (att.attribute_type_id = " + ATTRIBUTE_TYPE.TSK_SET_NAME.getTypeID() + ") " + //NON-NLS
+                "AND (art.artifact_type_id = " + ARTIFACT_TYPE.TSK_HASHSET_HIT.getTypeID() + ") " + //NON-NLS
+                "ORDER BY setname, parent_path, name, size"; //NON-NLS
+
+        try (CaseDbQuery dbQuery = skCase.executeQuery(hashsetHitsQuery)) {
             // Query for hashset hits
-            rs = skCase.runQuery("SELECT art.artifact_id, art.obj_id, att.value_text AS setname, f.name AS name, f.size AS size, f.parent_path AS parent_path " + //NON-NLS
-                                           "FROM blackboard_artifacts AS art, blackboard_attributes AS att, tsk_files AS f " + //NON-NLS
-                                           "WHERE (att.artifact_id = art.artifact_id) " + //NON-NLS
-                                                 "AND (f.obj_id = art.obj_id) " + //NON-NLS
-                                                 "AND (att.attribute_type_id = " + ATTRIBUTE_TYPE.TSK_SET_NAME.getTypeID() + ") " + //NON-NLS
-                                                 "AND (art.artifact_type_id = " + ARTIFACT_TYPE.TSK_HASHSET_HIT.getTypeID() + ") " + //NON-NLS
-                                           "ORDER BY setname, parent_path, name, size"); //NON-NLS
+            ResultSet resultSet = dbQuery.getResultSet();
             String currentSet = "";
-            while (rs.next()) {
+            while (resultSet.next()) {
                 // Check to see if all the TableReportModules have been canceled
                 if (tableModules.isEmpty()) {
                     break;
@@ -1103,15 +1093,15 @@ import org.sleuthkit.datamodel.TskData;
                 }
                 
                 // Get any tags that associated with this artifact and apply the tag filter.
-                HashSet<String> uniqueTagNames = getUniqueTagNames(rs.getLong("artifact_id")); //NON-NLS
+                HashSet<String> uniqueTagNames = getUniqueTagNames(resultSet.getLong("artifact_id")); //NON-NLS
                 if(failsTagFilter(uniqueTagNames, tagNamesFilter)) {
                     continue;
                 }                    
                 String tagsList = makeCommaSeparatedList(uniqueTagNames);
                                                                         
-                Long objId = rs.getLong("obj_id"); //NON-NLS
-                String set = rs.getString("setname"); //NON-NLS
-                String size = rs.getString("size"); //NON-NLS
+                Long objId = resultSet.getLong("obj_id"); //NON-NLS
+                String set = resultSet.getString("setname"); //NON-NLS
+                String size = resultSet.getString("size"); //NON-NLS
                 String uniquePath = "";
                 
                 try {
@@ -1152,16 +1142,9 @@ import org.sleuthkit.datamodel.TskData;
                 tableProgress.get(module).increment();
                 module.endDataType();
             }
-        } catch (SQLException ex) {
+        } catch (TskCoreException | SQLException ex) {
             errorList.add(NbBundle.getMessage(this.getClass(), "ReportGenerator.errList.failedQueryHashsetHits"));
-            logger.log(Level.SEVERE, "Failed to query hashsets hits.", ex); //NON-NLS
-        } finally {
-            if (rs != null) {
-                try {
-                    skCase.closeRunQuery(rs);
-                } catch (SQLException ex) {
-                }
-            }
+            logger.log(Level.SEVERE, "Failed to query hashsets hits: ", ex); //NON-NLS
         }
     }
         
@@ -1874,14 +1857,22 @@ import org.sleuthkit.datamodel.TskData;
      * @throws SQLException 
      */
      @SuppressWarnings("deprecation")
-    private HashSet<String> getUniqueTagNames(long artifactId) throws SQLException {
+    private HashSet<String> getUniqueTagNames(long artifactId) throws TskCoreException {
         HashSet<String> uniqueTagNames = new HashSet<>();
-        ResultSet tagNameRows = skCase.runQuery("SELECT display_name, artifact_id FROM tag_names AS tn, blackboard_artifact_tags AS bat " + //NON-NLS 
-            "WHERE tn.tag_name_id = bat.tag_name_id AND bat.artifact_id = " + artifactId); //NON-NLS
-        while (tagNameRows.next()) {
-            uniqueTagNames.add(tagNameRows.getString("display_name")); //NON-NLS
+        
+        String query = "SELECT display_name, artifact_id FROM tag_names AS tn, blackboard_artifact_tags AS bat " + //NON-NLS 
+            "WHERE tn.tag_name_id = bat.tag_name_id AND bat.artifact_id = " + artifactId; //NON-NLS
+        
+        try (CaseDbQuery dbQuery = skCase.executeQuery(query)) {
+            ResultSet tagNameRows = dbQuery.getResultSet();
+            while (tagNameRows.next()) {
+                uniqueTagNames.add(tagNameRows.getString("display_name")); //NON-NLS
+            }            
         }
-        skCase.closeRunQuery(tagNameRows);
+        catch (TskCoreException | SQLException ex) {
+            throw new TskCoreException("Error getting tag names for artifact: ", ex);
+        }
+
         return uniqueTagNames;
     }    
     

--- a/Core/src/org/sleuthkit/autopsy/timeline/TimeLineController.java
+++ b/Core/src/org/sleuthkit/autopsy/timeline/TimeLineController.java
@@ -78,6 +78,7 @@ import org.sleuthkit.autopsy.timeline.zooming.DescriptionLOD;
 import org.sleuthkit.autopsy.timeline.zooming.EventTypeZoomLevel;
 import org.sleuthkit.autopsy.timeline.zooming.ZoomParams;
 import org.sleuthkit.datamodel.SleuthkitCase;
+import org.sleuthkit.datamodel.SleuthkitCase.CaseDbQuery;
 import org.sleuthkit.datamodel.TskCoreException;
 
 /** Controller in the MVC design along with model = {@link FilteredEventsModel}
@@ -357,13 +358,15 @@ public class TimeLineController {
     @SuppressWarnings("deprecation")
     private long getCaseLastArtifactID(final SleuthkitCase sleuthkitCase) {
         long caseLastArtfId = -1;
-        try (ResultSet runQuery = sleuthkitCase.runQuery("select Max(artifact_id) as max_id from blackboard_artifacts")) { // NON-NLS
-            while (runQuery.next()) {
-                caseLastArtfId = runQuery.getLong("max_id"); // NON-NLS
+        String query = "select Max(artifact_id) as max_id from blackboard_artifacts"; // NON-NLS
+        
+        try (CaseDbQuery dbQuery = sleuthkitCase.executeQuery(query)) {
+            ResultSet resultSet = dbQuery.getResultSet();
+            while (resultSet.next()) {
+                caseLastArtfId = resultSet.getLong("max_id"); // NON-NLS
             }
-            sleuthkitCase.closeRunQuery(runQuery);
-        } catch (SQLException ex) {
-            Exceptions.printStackTrace(ex);
+        } catch (TskCoreException | SQLException ex) {
+            LOGGER.log(Level.SEVERE, "Error getting last artifact id: ", ex); // NON-NLS
         }
         return caseLastArtfId;
     }


### PR DESCRIPTION
...xecuteQuery.

executeQuery() returns a CaseDbQuery object which will automatically release the acquired lock when used in a try-with-resources block.