### PR TITLE
Replaced calls to SleuthkitCase.runQuery() with calls to SleuthkitCase.e...

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/datamodel/RecentFilesChildren.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/RecentFilesChildren.java
@@ -29,6 +29,8 @@ import org.sleuthkit.autopsy.coreutils.Logger;
 import org.openide.nodes.ChildFactory;
 import org.openide.nodes.Node;
 import org.sleuthkit.datamodel.SleuthkitCase;
+import org.sleuthkit.datamodel.SleuthkitCase.CaseDbQuery;
+import org.sleuthkit.datamodel.TskCoreException;
 
 /**
  *
@@ -82,21 +84,14 @@ import org.sleuthkit.datamodel.SleuthkitCase;
     @SuppressWarnings("deprecation")
     private long runTimeQuery(String query) {
         long result = 0;
-        ResultSet rs = null;
-        try {
-            rs = skCase.runQuery(query);
-            result = rs.getLong(1);
-        } catch (SQLException ex) {
-            logger.log(Level.WARNING, "Couldn't get recent files results", ex); //NON-NLS
-        } finally {
-            if (rs != null) {
-                try {
-                    skCase.closeRunQuery(rs);
-                } catch (SQLException ex) {
-                    logger.log(Level.WARNING, "Error closing result set after getting recent files results", ex); //NON-NLS
-                }
-            }
+
+        try (CaseDbQuery dbQuery = skCase.executeQuery(query)) {
+            ResultSet resultSet = dbQuery.getResultSet();
+            result = resultSet.getLong(1);
+        } catch (TskCoreException | SQLException ex) {
+            logger.log(Level.WARNING, "Couldn't get recent files results: ", ex); //NON-NLS
         }
+        
         return result;
     }
 }

--- a/Core/src/org/sleuthkit/autopsy/timeline/TimeLineController.java
+++ b/Core/src/org/sleuthkit/autopsy/timeline/TimeLineController.java
@@ -78,6 +78,7 @@ import org.sleuthkit.autopsy.timeline.zooming.DescriptionLOD;
 import org.sleuthkit.autopsy.timeline.zooming.EventTypeZoomLevel;
 import org.sleuthkit.autopsy.timeline.zooming.ZoomParams;
 import org.sleuthkit.datamodel.SleuthkitCase;
+import org.sleuthkit.datamodel.SleuthkitCase.CaseDbQuery;
 import org.sleuthkit.datamodel.TskCoreException;
 
 /** Controller in the MVC design along with model = {@link FilteredEventsModel}
@@ -357,13 +358,15 @@ public class TimeLineController {
     @SuppressWarnings("deprecation")
     private long getCaseLastArtifactID(final SleuthkitCase sleuthkitCase) {
         long caseLastArtfId = -1;
-        try (ResultSet runQuery = sleuthkitCase.runQuery("select Max(artifact_id) as max_id from blackboard_artifacts")) { // NON-NLS
-            while (runQuery.next()) {
-                caseLastArtfId = runQuery.getLong("max_id"); // NON-NLS
+        String query = "select Max(artifact_id) as max_id from blackboard_artifacts"; // NON-NLS
+        
+        try (CaseDbQuery dbQuery = sleuthkitCase.executeQuery(query)) {
+            ResultSet resultSet = dbQuery.getResultSet();
+            while (resultSet.next()) {
+                caseLastArtfId = resultSet.getLong("max_id"); // NON-NLS
             }
-            sleuthkitCase.closeRunQuery(runQuery);
-        } catch (SQLException ex) {
-            Exceptions.printStackTrace(ex);
+        } catch (TskCoreException | SQLException ex) {
+            LOGGER.log(Level.SEVERE, "Error getting last artifact id: ", ex); // NON-NLS
         }
         return caseLastArtfId;
     }


### PR DESCRIPTION
...xecuteQuery.

executeQuery() returns a CaseDbQuery object which will automatically release the acquired lock when used in a try-with-resources block.