### PR TITLE
Default build target now builds for PostgreSQL + SQLite

### DIFF
--- a/build-windows.xml
+++ b/build-windows.xml
@@ -29,10 +29,10 @@
         
         <property name="win64.TskLib.path" value="${env.TSK_HOME}/win32/x64/Release"/>
         <property name="win32.TskLib.path" value="${env.TSK_HOME}/win32/Release" />
-        <property name="win64.TskLib.path_postgres" value="${env.TSK_HOME}/win32/x64/Release_PostgreSql"/>
+        <property name="win64.TskLib.postgres_path" value="${env.POSTGRESQL_HOME_64}/bin"/>
         <available property="win64.TskLib.exists" type="dir" file="${win64.TskLib.path}" />
         <available property="win32.TskLib.exists" type="dir" file="${win32.TskLib.path}" />
-        <available property="win64.TskLib_postgres.exists" type="dir" file="${win64.TskLib.path_postgres}" />
+        <available property="win64.TskLib_postgres.exists" type="dir" file="{win64.TskLib.postgres_path}" />
     </target>
 
     <!-- The following copy the libtsk_jni dependencies to the Autopsy
@@ -43,42 +43,25 @@
         <fileset dir="${win64.TskLib.path}" id="win64dlls">
             <include name="libewf.dll" />
             <include name="zlib.dll"/>
-            <include name="libpq.dll"/>
+        </fileset>
+        
+        <fileset dir="${win64.TskLib.postgres_path}" id="postgres64dlls">
+            <include name="libeay32.dll"/>
+            <include name="ssleay32.dll"/>
             <include name="libintl-8.dll"/>
+            <include name="libpq.dll"/>
         </fileset>
 
         <copy todir="${amd64}" overwrite="true">
             <fileset refid="win64dlls" />
+            <fileset refid="postgres64dlls" />
         </copy>
-        
+
         <copy todir="${x86_64}" overwrite="true">
             <fileset refid="win64dlls" />
+            <fileset refid="postgres64dlls" />
         </copy>		
-        
     </target>
-
-    <!-- The following copy the libtsk_jni dependencies to the Autopsy
-         folder structure.  libtsk_jni is inside of the JAR file and contains
-         libtsk and the JNI code. -->
-    <!-- copy 64-bit dlls into the installer folder for Postgres build-->
-    <target name="copyWinTskLibs64_postgres_ToBaseDir" if="win64.TskLib_postgres.exists">
-        <fileset dir="${win64.TskLib.path_postgres}" id="win64_postgres_dlls">
-            <include name="libewf.dll" />
-            <include name="zlib.dll"/>
-            <include name="libpq.dll"/>
-            <include name="libintl-8.dll"/>
-        </fileset>
-
-        <copy todir="${amd64}" overwrite="true">
-            <fileset refid="win64_postgres_dlls" />
-        </copy>
-        
-        <copy todir="${x86_64}" overwrite="true">
-            <fileset refid="win64_postgres_dlls" />
-        </copy>		
-        
-    </target>
-
 
     <!-- copy 32-bit dlls into the installer folder -->
     <target name="copyWinTskLibs32ToBaseDir" if="win32.TskLib.exists">
@@ -111,13 +94,6 @@
         <antcall target="copyWinTskLibs64ToBaseDir" inheritRefs="true" />
     </target>
 
-    <!-- This gets called from the main build.xml -->
-    <target name="copyLibsToBaseDir_postgres" depends="checkTskLibDirs" description="Copy windows dlls to the correct location." >
-        <antcall target="makeBaseLibDirs" inheritRefs="true" />
-        <antcall target="copyWinTskLibs64_postgres_ToBaseDir" inheritRefs="true" />
-    </target>
-
-            
     <!-- CRT LIBS TO ZIP  - gets called from build.xml -->
     <target name="copyLibsToZip" depends="copyCRT32ToZIP,copyCRT64ToZIP"/>
     

--- a/build.xml
+++ b/build.xml
@@ -48,9 +48,16 @@
         <echo> TSK_HOME: ${env.TSK_HOME}</echo>
     </target>
     
-    
-    
-    
+    <!-- Verify that the POSTGRESQL_HOME_64 env variable is set -->
+    <target name="findPostgresHome64">
+        <property environment="env"/>
+        <condition property="postgresFound">
+            <isset property="env.POSTGRESQL_HOME_64"/>
+        </condition>
+        <fail unless="postgresFound" message="POSTGRESQL_HOME_64 must be set as an environment variable."/>
+        <echo> POSTGRESQL_HOME_64: ${env.POSTGRESQL_HOME_64}</echo>
+    </target>
+        
     <!-- This target will create a custom ZIP file for us.  It first uses the general
       ZIP target and then opens it up and adds in any files that we want.  This is where we customize the
       version number. -->
@@ -165,30 +172,8 @@
         </condition>
     </target>
     
-     <target name="-init_postgres" depends="-taskdefs,-convert-old-project,getProps,getJunit,copyLibsToBaseDir_postgres">
-        <convertclusterpath from="${cluster.path.evaluated}" to="cluster.path.final" id="cluster.path.id"/>
-        <sortsuitemodules unsortedmodules="${modules}" sortedmodulesproperty="modules.sorted"/>
-        <property name="cluster" location="build/cluster"/>
-        <echo level="verbose">Suite in ${basedir} with clusters ${cluster.path.final}, build cluster ${cluster}, and sorted modules ${modules.sorted}</echo>
-        <!-- synchronize with SuiteProject -->
-        <property name="disabled.modules" value=""/>
-        <property name="enabled.clusters" value=""/>
-        <property name="disabled.clusters" value=""/>
-
-        <property name="branding.dir" location="branding"/>
-        <property name="dist.dir" location="dist"/>
-        
-        <condition property="run.branding"> <!-- #84689 -->
-            <and>
-                <available file="${branding.dir}" type="dir"/>
-                <isset property="branding.token"/>
-            </and>
-        </condition>
-    </target>
-    
     <!-- override build to add branding -->
-    <target name="build" depends="build-brand,suite.build" description="Compiles autopsy and produces a basic branded build that can run on a dev. system" />
-    <target name="build_postgres" depends="build-brand_postgres,suite.build" description="Compiles autopsy and produces a basic branded build that can run on a dev. system" />
+    <target name="build" depends="findPostgresHome64, build-brand,suite.build" description="Compiles autopsy and produces a basic branded build that can run on a dev. system" />
  
     <target name="build-brand" depends="-init">
         
@@ -214,34 +199,6 @@
             <entry key="app.version" value="${app.version}" />
             <entry key="build.type" value="${build.type}" />
         </propertyfile>
-        
-    </target>
-
-        <target name="build-brand_postgres" depends="-init_postgres">
-        
-        <echo>${app.name} branding</echo>
-          
-        <propertyfile
-        file="${branding.dir}/core/core.jar/org/netbeans/core/startup/Bundle.properties" 
-        comment="Updated by build script">
-            <entry key="currentVersion" value="${app.title} ${app.version}" />
-        </propertyfile>
- 
-        <propertyfile
-        file="${branding.dir}/modules/org-netbeans-core-windows.jar/org/netbeans/core/windows/view/ui/Bundle.properties"
-        comment="Updated by build script">
-            <entry key="CTL_MainWindow_Title" value="${app.title} ${app.version}" />
-            <entry key="CTL_MainWindow_Title_No_Project" value="${app.title} ${app.version}" />
-        </propertyfile>
-        
-        <propertyfile
-        file="${basedir}/Core/src/org/sleuthkit/autopsy/coreutils/Version.properties"
-        comment="Updated by build script">
-            <entry key="app.name" value="${app.title}" />
-            <entry key="app.version" value="${app.version}" />
-            <entry key="build.type" value="${build.type}" />
-        </propertyfile>
-        
     </target>
     
     <!-- This seems really bad to be hard coded, but I couldn't find a better solution -->
@@ -249,6 +206,7 @@
         <pathelement location="${basedir}/build/cluster/modules/org-sleuthkit-datamodel.jar"/>
         <path refid="cluster.path.id" />
     </path>
+    
     <target name="jni" depends="build,findTSK">
         <javah verbose="yes" outputFile="${env.TSK_HOME}/bindings/java/tsk_jni/tsk_jni/dataModel_SleuthkitJNI.h">
             <class name="org.sleuthkit.datamodel.SleuthkitJNI" />


### PR DESCRIPTION
To build Autopsy, you must have a 64-bit version of PostgreSQL installed. It is available at http://www.postgresql.org/download/
You need to define an environment variable called POSTGRESQL_HOME_64 and point it to the PostgreSQL folder containing but not including the bin folder.
Here is an example: 
POSTGRESQL_HOME_64=C:\Program Files\PostgreSQL\9.4

In Visual Studio, build The SleuthKit (TSK) selecting one of following targets:
Debug_PostgreSQL x64
Release_PostgreSQL x64

Then, in NetBeans, build the DataModel with "Clean and Build"
Then, also in NetBeans, build Autopsy with "Clean and Build"


For those interested in just using TSK and the DataModel:
Build TSK with non-PostgreSQL targets in Visual Studio.
Then, build the DataModel with two steps:
    1) clean 
    2) select one of the two following targets and build that:
        a) dist-SQLite
        b) dist-SQLite-debug 
Then you can use the DataModel and JNI to access TSK.
