### PR TITLE
KeywordSearchResultFactory.getOneHitPerObject() returns consistent results

### DIFF
--- a/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/LuceneQuery.java
+++ b/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/LuceneQuery.java
@@ -322,6 +322,7 @@ class LuceneQuery implements KeywordSearchQuery {
             List<String> snippetList = highlightResponse.get(docId).get(Server.Schema.TEXT.toString());
             // list is null if there wasn't a snippet
             if (snippetList != null) {
+                snippetList.sort(null);
                 snippet = EscapeUtil.unEscapeHtml(snippetList.get(0)).trim();
             }
         }

--- a/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/QueryResults.java
+++ b/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/QueryResults.java
@@ -173,7 +173,7 @@ class QueryResults {
      */
     private Collection<KeywordHit> getOneHitPerObject(Keyword keyword) {
 
-        HashMap<Long, KeywordHit> hits = new HashMap();
+        HashMap<Long, KeywordHit> hits = new HashMap<Long, KeywordHit>();
 
         // create a list of KeywordHits. KeywordHits with lowest chunkID is added the the list.
         for(KeywordHit hit: getResults(keyword)) {


### PR DESCRIPTION
Also, warnings handled