### PR TITLE
Fixes for Image Gallery case changing/closing

### DIFF
--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/ImageGalleryController.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/ImageGalleryController.java
@@ -307,8 +307,8 @@ public final class ImageGalleryController {
 
     private void restartWorker() {
         if (dbWorkerThread != null) {
+            // Keep using the same worker thread if one exists
             return;
-            //dbWorkerThread.cancelAllTasks();
         }
         dbWorkerThread = new DBWorkerThread();
 
@@ -335,7 +335,6 @@ public final class ImageGalleryController {
 
         // if we add this line icons are made as files are analyzed rather than on demand.
         // db.addUpdatedFileListener(IconCache.getDefault());
-        // @@@ I think we should add a checkhere to see if the thread already exists
         restartWorker();
         historyManager.clear();
         groupManager.setDB(db);
@@ -348,14 +347,12 @@ public final class ImageGalleryController {
     public synchronized void reset() {
         LOGGER.info("resetting ImageGalleryControler to initial state.");
         selectionModel.clearSelection();
-        
         Platform.runLater(() -> {
             historyManager.clear();
         });
 
         Toolbar.getDefault().reset();
         groupManager.clear();
-        
         if (db != null) {
             db.closeDBCon();
         }
@@ -627,7 +624,7 @@ public final class ImageGalleryController {
                 DrawableFile<?> drawableFile = DrawableFile.create(getFile(), true);
                 db.updateFile(drawableFile);
             } catch (NullPointerException ex){
-                // This is one of the places where we get an error if the case is closed during processing.
+                // This is one of the places where we get many errors if the case is closed during processing.
                 // We don't want to print out a ton of exceptions if this is the case.
                 if(Case.isCaseOpen()){
                     Logger.getLogger(UpdateFileTask.class.getName()).log(Level.SEVERE, "Error in UpdateFile task");
@@ -653,7 +650,7 @@ public final class ImageGalleryController {
             try{
               db.removeFile(getFile().getId());
             } catch (NullPointerException ex){
-                // This is one of the places where we get an error if the case is closed during processing.
+                // This is one of the places where we get many errors if the case is closed during processing.
                 // We don't want to print out a ton of exceptions if this is the case.
                 if(Case.isCaseOpen()){
                     Logger.getLogger(RemoveFileTask.class.getName()).log(Level.SEVERE, "Case was closed out from underneath RemoveFile task");

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/ImageGalleryController.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/ImageGalleryController.java
@@ -344,8 +344,10 @@ public final class ImageGalleryController {
      */
     public synchronized void reset() {
         LOGGER.info("resetting ImageGalleryControler to initial state.");
-        selectionModel.clearSelection();
         Category.unregisterAllFileListeners();
+        TagUtils.unregisterAllFileListeners();
+        selectionModel.clearSelection();
+        
         Platform.runLater(() -> {
             historyManager.clear();
         });

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/ImageGalleryController.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/ImageGalleryController.java
@@ -58,6 +58,7 @@ import org.sleuthkit.autopsy.coreutils.History;
 import org.sleuthkit.autopsy.coreutils.Logger;
 import org.sleuthkit.autopsy.imagegallery.datamodel.DrawableDB;
 import org.sleuthkit.autopsy.imagegallery.datamodel.DrawableFile;
+import org.sleuthkit.autopsy.imagegallery.datamodel.Category;
 import org.sleuthkit.autopsy.imagegallery.grouping.GroupManager;
 import org.sleuthkit.autopsy.imagegallery.grouping.GroupViewState;
 import org.sleuthkit.autopsy.imagegallery.gui.NoGroupsDialog;
@@ -303,7 +304,8 @@ public final class ImageGalleryController {
 
     private void restartWorker() {
         if (dbWorkerThread != null) {
-            dbWorkerThread.cancelAllTasks();
+            return;
+            //dbWorkerThread.cancelAllTasks();
         }
         dbWorkerThread = new DBWorkerThread();
 
@@ -330,6 +332,7 @@ public final class ImageGalleryController {
 
         // if we add this line icons are made as files are analyzed rather than on demand.
         // db.addUpdatedFileListener(IconCache.getDefault());
+        // @@@ I think we should add a checkhere to see if the thread already exists
         restartWorker();
         historyManager.clear();
         groupManager.setDB(db);
@@ -342,6 +345,7 @@ public final class ImageGalleryController {
     public synchronized void reset() {
         LOGGER.info("resetting ImageGalleryControler to initial state.");
         selectionModel.clearSelection();
+        Category.unregisterAllFileListeners();
         Platform.runLater(() -> {
             historyManager.clear();
         });

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/ImageGalleryController.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/ImageGalleryController.java
@@ -347,8 +347,6 @@ public final class ImageGalleryController {
      */
     public synchronized void reset() {
         LOGGER.info("resetting ImageGalleryControler to initial state.");
-        Category.unregisterAllFileListeners();
-        TagUtils.unregisterAllFileListeners();
         selectionModel.clearSelection();
         
         Platform.runLater(() -> {
@@ -357,6 +355,7 @@ public final class ImageGalleryController {
 
         Toolbar.getDefault().reset();
         groupManager.clear();
+        
         if (db != null) {
             db.closeDBCon();
         }

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/ImageGalleryController.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/ImageGalleryController.java
@@ -840,11 +840,9 @@ public final class ImageGalleryController {
 
             } catch (TskCoreException ex) {
                 Logger.getLogger(PrePopulateDataSourceFiles.class.getName()).log(Level.WARNING, "failed to transfer all database contents", ex);
-            } catch (IllegalStateException ex) {
-                Logger.getLogger(PrePopulateDataSourceFiles.class.getName()).log(Level.SEVERE, "Case was closed out from underneath prepopulating database");
-            } catch (NullPointerException ex) {
-                Logger.getLogger(PrePopulateDataSourceFiles.class.getName()).log(Level.SEVERE, "Case was closed out from underneath prepopulating database");
-            }
+            } catch (IllegalStateException | NullPointerException ex) {
+                Logger.getLogger(PrePopulateDataSourceFiles.class.getName()).log(Level.WARNING, "Case was closed out from underneath prepopulating database");
+            } 
 
             progressHandle.finish();
         }

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/TagUtils.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/TagUtils.java
@@ -20,6 +20,7 @@ package org.sleuthkit.autopsy.imagegallery;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.logging.Level;
 import javafx.event.ActionEvent;
@@ -33,6 +34,7 @@ import org.sleuthkit.autopsy.coreutils.Logger;
 import org.sleuthkit.autopsy.imagegallery.actions.AddDrawableTagAction;
 import org.sleuthkit.autopsy.imagegallery.datamodel.Category;
 import org.sleuthkit.autopsy.imagegallery.datamodel.DrawableAttribute;
+import org.sleuthkit.autopsy.imagegallery.gui.SingleDrawableViewBase;
 import org.sleuthkit.datamodel.TagName;
 import org.sleuthkit.datamodel.TskCoreException;
 
@@ -108,6 +110,25 @@ public class TagUtils {
     public static void unregisterListener(TagListener aThis) {
         synchronized (listeners) {
             listeners.remove(aThis);
+        }
+    }
+    
+        /**
+     * Clears out all the existing file-type listeners.
+     * To be called when the case is closed to prevent
+     * old abstract files files from trying to access the closed
+     * database.
+     */
+    public static void unregisterAllFileListeners(){
+        synchronized(listeners){
+            Iterator<TagListener> it = listeners.iterator();
+            while(it.hasNext()){
+                
+                TagListener obj = it.next();
+                if(obj instanceof SingleDrawableViewBase){
+                    it.remove();
+                }
+            }
         }
     }
 

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/TagUtils.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/TagUtils.java
@@ -20,7 +20,6 @@ package org.sleuthkit.autopsy.imagegallery;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import java.util.logging.Level;
 import javafx.event.ActionEvent;
@@ -34,7 +33,6 @@ import org.sleuthkit.autopsy.coreutils.Logger;
 import org.sleuthkit.autopsy.imagegallery.actions.AddDrawableTagAction;
 import org.sleuthkit.autopsy.imagegallery.datamodel.Category;
 import org.sleuthkit.autopsy.imagegallery.datamodel.DrawableAttribute;
-import org.sleuthkit.autopsy.imagegallery.gui.SingleDrawableViewBase;
 import org.sleuthkit.datamodel.TagName;
 import org.sleuthkit.datamodel.TskCoreException;
 

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/TagUtils.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/TagUtils.java
@@ -112,25 +112,6 @@ public class TagUtils {
             listeners.remove(aThis);
         }
     }
-    
-        /**
-     * Clears out all the existing file-type listeners.
-     * To be called when the case is closed to prevent
-     * old abstract files files from trying to access the closed
-     * database.
-     */
-    public static void unregisterAllFileListeners(){
-        synchronized(listeners){
-            Iterator<TagListener> it = listeners.iterator();
-            while(it.hasNext()){
-                
-                TagListener obj = it.next();
-                if(obj instanceof SingleDrawableViewBase){
-                    it.remove();
-                }
-            }
-        }
-    }
 
     /**
      * @param tn the value of tn

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/ThumbnailCache.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/ThumbnailCache.java
@@ -233,7 +233,7 @@ public enum ThumbnailCache {
             }
             return bi;
         } catch (IOException ex) {
-            LOGGER.log(Level.WARNING, "Could not read image: " + file.getName(), ex);
+            LOGGER.log(Level.WARNING, "Could not read image: " + file.getName());
             return null;
         }
     }

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/Category.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/Category.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Iterator;
 import java.util.logging.Level;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
@@ -37,6 +38,7 @@ import javax.annotation.concurrent.GuardedBy;
 import org.sleuthkit.autopsy.coreutils.Logger;
 import org.sleuthkit.autopsy.imagegallery.TagUtils;
 import org.sleuthkit.autopsy.imagegallery.actions.CategorizeAction;
+import org.sleuthkit.autopsy.imagegallery.gui.SingleDrawableViewBase;
 import org.sleuthkit.datamodel.TagName;
 import org.sleuthkit.datamodel.TskCoreException;
 
@@ -82,6 +84,26 @@ public enum Category implements Comparable<Category> {
     public static void unregisterListener(CategoryListener aThis) {
         synchronized (listeners) {
             listeners.remove(aThis);
+        }
+    }
+    
+    /**
+     * Clears out all the existing file-type listeners.
+     * To be called when the case is closed to prevent
+     * old abstract files files from trying to access the closed
+     * database.
+     */
+    public static void unregisterAllFileListeners(){
+        synchronized(listeners){
+            Iterator<CategoryListener> it = listeners.iterator();
+            while(it.hasNext()){
+                
+                CategoryListener obj = it.next();
+                if(obj instanceof SingleDrawableViewBase){
+                    System.out.println("  Removing file");
+                    it.remove();
+                }
+            }
         }
     }
 

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/Category.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/Category.java
@@ -25,7 +25,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Iterator;
 import java.util.logging.Level;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
@@ -38,7 +37,6 @@ import javax.annotation.concurrent.GuardedBy;
 import org.sleuthkit.autopsy.coreutils.Logger;
 import org.sleuthkit.autopsy.imagegallery.TagUtils;
 import org.sleuthkit.autopsy.imagegallery.actions.CategorizeAction;
-import org.sleuthkit.autopsy.imagegallery.gui.SingleDrawableViewBase;
 import org.sleuthkit.datamodel.TagName;
 import org.sleuthkit.datamodel.TskCoreException;
 

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/Category.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/Category.java
@@ -100,7 +100,6 @@ public enum Category implements Comparable<Category> {
                 
                 CategoryListener obj = it.next();
                 if(obj instanceof SingleDrawableViewBase){
-                    System.out.println("  Removing file");
                     it.remove();
                 }
             }

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/Category.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/Category.java
@@ -86,26 +86,7 @@ public enum Category implements Comparable<Category> {
             listeners.remove(aThis);
         }
     }
-    
-    /**
-     * Clears out all the existing file-type listeners.
-     * To be called when the case is closed to prevent
-     * old abstract files files from trying to access the closed
-     * database.
-     */
-    public static void unregisterAllFileListeners(){
-        synchronized(listeners){
-            Iterator<CategoryListener> it = listeners.iterator();
-            while(it.hasNext()){
-                
-                CategoryListener obj = it.next();
-                if(obj instanceof SingleDrawableViewBase){
-                    it.remove();
-                }
-            }
-        }
-    }
-
+  
     public KeyCode getHotKeycode() {
         return KeyCode.getKeyCode(Integer.toString(id));
     }

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/DrawableDB.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/DrawableDB.java
@@ -129,9 +129,9 @@ public class DrawableDB {
 
     volatile private Connection con;
 
-    private static final ReentrantReadWriteLock rwLock = new ReentrantReadWriteLock(true); //use fairness policy
+    private final ReentrantReadWriteLock rwLock = new ReentrantReadWriteLock(true); //use fairness policy
 
-    private static final Lock DBLock = rwLock.writeLock(); //using exclusing lock for all db ops for now
+    private final Lock DBLock = rwLock.writeLock(); //using exclusing lock for all db ops for now
 
     static {//make sure sqlite driver is loaded // possibly redundant
         try {
@@ -149,7 +149,7 @@ public class DrawableDB {
      * MUST always call dbWriteUnLock() as early as possible, in the same thread
      * where dbWriteLock() was called
      */
-    public static void dbWriteLock() {
+    public void dbWriteLock() {
         //Logger.getLogger("LOCK").log(Level.INFO, "Locking " + rwLock.toString());
         DBLock.lock();
     }
@@ -159,7 +159,7 @@ public class DrawableDB {
      * dbWriteLock(). Call in "finally" block to ensure the lock is always
      * released.
      */
-    public static void dbWriteUnlock() {
+    public void dbWriteUnlock() {
         //Logger.getLogger("LOCK").log(Level.INFO, "UNLocking " + rwLock.toString());
         DBLock.unlock();
     }

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/DrawableDB.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/DrawableDB.java
@@ -1183,7 +1183,12 @@ public class DrawableDB {
                 try {
                     con.setAutoCommit(true);
                 } catch (SQLException ex) {
-                    LOGGER.log(Level.SEVERE, "Error setting auto-commit to true.", ex);
+                    if(Case.isCaseOpen()){
+                        LOGGER.log(Level.SEVERE, "Error setting auto-commit to true.", ex);
+                    }
+                    else{
+                        LOGGER.log(Level.SEVERE, "Error setting auto-commit to true - case is closed");
+                    }
                 } finally {
                     closed = true;
                     dbWriteUnlock();

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/DrawableDB.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/DrawableDB.java
@@ -604,18 +604,13 @@ public class DrawableDB {
 
             tr.addUpdatedFile(f.getId());
 
-        } catch (SQLException ex) {
+        } catch (SQLException | NullPointerException ex) {
             // This is one of the places where we get an error if the case is closed during processing,
-            // which doesn't need to be reported.
+            // which doesn't need to be reported here.
             if(Case.isCaseOpen()){
                 LOGGER.log(Level.SEVERE, "failed to insert/update file" + f.getName(), ex);
             }
-        } catch (NullPointerException ex) {
-            if(Case.isCaseOpen()){
-                LOGGER.log(Level.SEVERE, "failed to insert/update file" + f.getName(), ex);
-            }
-        } 
-        finally {
+        } finally {
             dbWriteUnlock();
         }
     }
@@ -924,7 +919,10 @@ public class DrawableDB {
             insertGroupStmt.setString(2, groupBy.attrName.toString());
             insertGroupStmt.execute();
         } catch (SQLException sQLException) {
-            LOGGER.log(Level.SEVERE, "Unable to insert group", sQLException);
+            // Don't need to report it if the case was closed
+            if(Case.isCaseOpen()){
+                LOGGER.log(Level.SEVERE, "Unable to insert group", sQLException);
+            }
         } finally {
             dbWriteUnlock();
         }

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/DrawableFile.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/DrawableFile.java
@@ -215,6 +215,7 @@ public abstract class DrawableFile<T extends AbstractFile> extends AbstractFile 
                 }
             }
         } catch (TskCoreException ex) {
+            Logger.getLogger(DrawableFile.class.getName()).log(Level.WARNING, "problem looking up attributes for file ", ex);
             Logger.getAnonymousLogger().log(Level.WARNING, "problem looking up {0}/{1}" + " " + " for {2}", new Object[]{artType.getDisplayName(), attrType.getDisplayName(), getName()});
         }
 

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/DrawableFile.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/DrawableFile.java
@@ -174,6 +174,9 @@ public abstract class DrawableFile<T extends AbstractFile> extends AbstractFile 
         } catch (TskCoreException ex) {
             Logger.getAnonymousLogger().log(Level.WARNING, "problem looking up " + DrawableAttribute.TAGS.getDisplayName() + " for " + file.getName(), ex);
             return Collections.emptySet();
+        } catch (IllegalStateException ex) {
+            Logger.getAnonymousLogger().log(Level.SEVERE, "there is no case open; failed to look up " + DrawableAttribute.TAGS.getDisplayName() + " for " + file.getName());
+            return null;
         }
     }
 
@@ -282,7 +285,12 @@ public abstract class DrawableFile<T extends AbstractFile> extends AbstractFile 
             }
         } catch (TskCoreException ex) {
             Logger.getLogger(DrawableFile.class.getName()).log(Level.WARNING, "problem looking up category for file " + this.getName(), ex);
+        } catch (IllegalStateException ex){
+            // We get here if the case has been closed, in which case we don't need to print out a ton of warnings.
+            //Logger.getLogger(DrawableFile.class.getName()).log(Level.WARNING, "problem looking up category for file " + this.getName() + 
+            //        " - no case open");
         }
+        
     }
 
     public abstract Image getThumbnail();

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/DrawableFile.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/DrawableFile.java
@@ -176,7 +176,7 @@ public abstract class DrawableFile<T extends AbstractFile> extends AbstractFile 
             return Collections.emptySet();
         } catch (IllegalStateException ex) {
             Logger.getAnonymousLogger().log(Level.WARNING, "there is no case open; failed to look up " + DrawableAttribute.TAGS.getDisplayName() + " for " + file.getName());
-            return null;
+            return Collections.emptySet();
         }
     }
 
@@ -286,9 +286,7 @@ public abstract class DrawableFile<T extends AbstractFile> extends AbstractFile 
         } catch (TskCoreException ex) {
             Logger.getLogger(DrawableFile.class.getName()).log(Level.WARNING, "problem looking up category for file " + this.getName(), ex);
         } catch (IllegalStateException ex){
-            // We get here if the case has been closed, in which case we don't need to print out a ton of warnings.
-            //Logger.getLogger(DrawableFile.class.getName()).log(Level.WARNING, "problem looking up category for file " + this.getName() + 
-            //        " - no case open");
+            // We get here many times if the case is closed during ingest, so don't print out a ton of warnings.
         }
         
     }

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/DrawableFile.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/DrawableFile.java
@@ -175,7 +175,7 @@ public abstract class DrawableFile<T extends AbstractFile> extends AbstractFile 
             Logger.getAnonymousLogger().log(Level.WARNING, "problem looking up " + DrawableAttribute.TAGS.getDisplayName() + " for " + file.getName(), ex);
             return Collections.emptySet();
         } catch (IllegalStateException ex) {
-            Logger.getAnonymousLogger().log(Level.SEVERE, "there is no case open; failed to look up " + DrawableAttribute.TAGS.getDisplayName() + " for " + file.getName());
+            Logger.getAnonymousLogger().log(Level.WARNING, "there is no case open; failed to look up " + DrawableAttribute.TAGS.getDisplayName() + " for " + file.getName());
             return null;
         }
     }
@@ -215,7 +215,6 @@ public abstract class DrawableFile<T extends AbstractFile> extends AbstractFile 
                 }
             }
         } catch (TskCoreException ex) {
-            Logger.getLogger(DrawableFile.class.getName()).log(Level.WARNING, "problem looking up attributes for file ", ex);
             Logger.getAnonymousLogger().log(Level.WARNING, "problem looking up {0}/{1}" + " " + " for {2}", new Object[]{artType.getDisplayName(), attrType.getDisplayName(), getName()});
         }
 

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/grouping/GroupManager.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/grouping/GroupManager.java
@@ -563,7 +563,10 @@ public class GroupManager implements FileUpdateEvent.FileUpdateListener {
         } catch (TskCoreException ex) {
             LOGGER.log(Level.WARNING, "TSK error getting files in Category:" + category.getDisplayName(), ex);
             throw ex;
-        }        
+        } catch(IllegalStateException ex){
+            // This is one of the places where we get an error if the case is closed during processing.
+            throw new TskCoreException("Case closed while getting files");
+        }
     
     }
 

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/grouping/GroupManager.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/grouping/GroupManager.java
@@ -564,7 +564,6 @@ public class GroupManager implements FileUpdateEvent.FileUpdateListener {
             LOGGER.log(Level.WARNING, "TSK error getting files in Category:" + category.getDisplayName(), ex);
             throw ex;
         } catch(IllegalStateException ex){
-            // This is one of the places where we get an error if the case is closed during processing.
             throw new TskCoreException("Case closed while getting files");
         }
     

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/gui/SingleDrawableViewBase.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/gui/SingleDrawableViewBase.java
@@ -359,6 +359,7 @@ public abstract class SingleDrawableViewBase extends AnchorPane implements Drawa
         if (Objects.equals(fileID, this.fileID) == false) {
             this.fileID = fileID;
             disposeContent();
+            
             if (this.fileID == null || Case.isCaseOpen() == false) {
                 Category.unregisterListener(this);
                 TagUtils.unregisterListener(this);

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/gui/SummaryTablePane.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/gui/SummaryTablePane.java
@@ -111,7 +111,7 @@ public class SummaryTablePane extends AnchorPane implements Category.CategoryLis
                 try {
                     data.add(new Pair<>(cat, ImageGalleryController.getDefault().getGroupManager().countFilesWithCategory(cat)));
                 } catch (TskCoreException ex) {
-                    Exceptions.printStackTrace(ex);
+                    //Exceptions.printStackTrace(ex);
                 }
             }
             Platform.runLater(() -> {

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/gui/SummaryTablePane.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/gui/SummaryTablePane.java
@@ -22,6 +22,7 @@ import java.net.URL;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.ResourceBundle;
+import java.util.logging.Level;
 import javafx.application.Platform;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.FXCollections;
@@ -36,8 +37,10 @@ import javafx.scene.layout.VBox;
 import javafx.util.Pair;
 import org.openide.util.Exceptions;
 import org.sleuthkit.autopsy.casemodule.Case;
+import org.sleuthkit.autopsy.coreutils.Logger;
 import org.sleuthkit.autopsy.imagegallery.FXMLConstructor;
 import org.sleuthkit.autopsy.imagegallery.ImageGalleryController;
+import org.sleuthkit.autopsy.imagegallery.TagUtils;
 import org.sleuthkit.autopsy.imagegallery.datamodel.Category;
 import org.sleuthkit.datamodel.TskCoreException;
 
@@ -111,7 +114,7 @@ public class SummaryTablePane extends AnchorPane implements Category.CategoryLis
                 try {
                     data.add(new Pair<>(cat, ImageGalleryController.getDefault().getGroupManager().countFilesWithCategory(cat)));
                 } catch (TskCoreException ex) {
-                    //Exceptions.printStackTrace(ex);
+                    Logger.getLogger(SummaryTablePane.class.getName()).log(Level.WARNING, "Error performing category file count");
                 }
             }
             Platform.runLater(() -> {


### PR DESCRIPTION
Better cleanup of the groupPane.
Print fewer exceptions that come from the case closing.
Re-use the same worker thread.