### PR TITLE
Ensure code executed on JMS thread dispatches to EDT

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/directorytree/DirectoryTreeTopComponent.java
+++ b/Core/src/org/sleuthkit/autopsy/directorytree/DirectoryTreeTopComponent.java
@@ -1,7 +1,7 @@
 /*
  * Autopsy Forensic Browser
  *
- * Copyright 2011-2014 Basis Technology Corp.
+ * Copyright 2011-2015 Basis Technology Corp.
  * Contact: carrier <at> sleuthkit <dot> org
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -84,21 +84,14 @@ import org.sleuthkit.datamodel.TskException;
 // Registered as a service provider for DataExplorer in layer.xml
 public final class DirectoryTreeTopComponent extends TopComponent implements DataExplorer, ExplorerManager.Provider, BlackboardResultViewer {
 
-    private transient ExplorerManager em = new ExplorerManager();
+    private final transient ExplorerManager em = new ExplorerManager();
     private static DirectoryTreeTopComponent instance;
-    private DataResultTopComponent dataResult = new DataResultTopComponent(true, NbBundle.getMessage(this.getClass(),
+    private final DataResultTopComponent dataResult = new DataResultTopComponent(true, NbBundle.getMessage(this.getClass(),
             "DirectoryTreeTopComponent.title.text"));
-    private LinkedList<String[]> backList;
-    private LinkedList<String[]> forwardList;
-    /**
-     * path to the icon used by the component and its open action
-     */
-//    static final String ICON_PATH = "SET/PATH/TO/ICON/HERE";
+    private final LinkedList<String[]> backList;
+    private final LinkedList<String[]> forwardList;
     private static final String PREFERRED_ID = "DirectoryTreeTopComponent"; //NON-NLS
-    private PropertyChangeSupport pcs;
-    // for error handling
-    private JPanel caller;
-    private String className = this.getClass().toString();
+    private final PropertyChangeSupport pcs;
     private static final Logger logger = Logger.getLogger(DirectoryTreeTopComponent.class.getName());
     private RootContentChildren contentChildren;
 
@@ -795,56 +788,6 @@ public final class DirectoryTreeTopComponent extends TopComponent implements Dat
     }
 
     /**
-     * Refreshes the nodes in the tree to reflect updates in the database should
-     * be called in the gui thread
-     */
-//    public void refreshResultsTree(final BlackboardArtifact.ARTIFACT_TYPE... types) {
-//        //save current selection
-//        Node selectedNode = getSelectedNode();
-//        final String[] selectedPath = NodeOp.createPath(selectedNode, em.getRootContext());
-//
-//        //TODO: instead, we should choose a specific key to refresh? Maybe?
-//        //contentChildren.refreshKeys();
-//
-//        Children dirChilds = em.getRootContext().getChildren();
-//
-//        Node results = dirChilds.findChild(ResultsNode.NAME);
-//        if (results == null) {
-//            logger.log(Level.SEVERE, "Cannot find Results filter node, won't refresh the bb tree"); //NON-NLS
-//            return;
-//        }
-//        
-//        OriginalNode original = results.getLookup().lookup(OriginalNode.class);
-//        ResultsNode resultsNode = (ResultsNode) original.getNode();
-//        RootContentChildren resultsNodeChilds = (RootContentChildren) resultsNode.getChildren();
-//        resultsNodeChilds.refreshKeys(types);
-//
-//        
-//        final TreeView tree = getTree();
-//        // @@@ tree.expandNode(results);
-//
-//        Children resultsChilds = results.getChildren();
-//        if (resultsChilds == null) { 
-//            return;
-//        }
-//
-//        Node childNode = resultsChilds.findChild(KeywordHits.NAME);
-//        if (childNode == null) { 
-//            return;
-//        }
-//        // @@@tree.expandNode(childNode);
-//
-//        childNode = resultsChilds.findChild(ExtractedContent.NAME);
-//        if (childNode == null) {
-//            return;
-//        }
-//        tree.expandNode(childNode);
-//
-//        //restores selection if it was under the Results node
-//        //@@@ setSelectedNode(selectedPath, ResultsNode.NAME);
-//        
-//    }
-    /**
      * Set the selected node using a path to a previously selected node.
      *
      * @param previouslySelectedNodePath Path to a previously selected node.
@@ -1013,10 +956,6 @@ public final class DirectoryTreeTopComponent extends TopComponent implements Dat
                 new BlackboardArtifactNode(art)).actionPerformed(null);
     }
 
-//    private class HistoryManager<T> {
-//        private Stack<T> past, future;
-//
-//    }
     @Override
     public void addOnFinishedListener(PropertyChangeListener l) {
         DirectoryTreeTopComponent.this.addPropertyChangeListener(l);

--- a/Core/src/org/sleuthkit/autopsy/filesearch/DateSearchFilter.java
+++ b/Core/src/org/sleuthkit/autopsy/filesearch/DateSearchFilter.java
@@ -37,8 +37,8 @@ import javax.swing.JLabel;
 import javax.swing.JList;
 import javax.swing.JSeparator;
 import javax.swing.ListCellRenderer;
+import javax.swing.SwingUtilities;
 import javax.swing.border.EmptyBorder;
-
 import org.openide.util.NbBundle;
 import org.sleuthkit.autopsy.casemodule.Case;
 
@@ -237,26 +237,28 @@ class DateSearchFilter extends AbstractFileSearchFilter<DateSearchPanel> {
 
         @Override
         public void propertyChange(PropertyChangeEvent evt) {
-            String changed = evt.getPropertyName();
-            Object oldValue = evt.getOldValue();
-            Object newValue = evt.getNewValue();
-
-            if (changed.equals(Case.Events.CURRENT_CASE.toString())) {
-                // create or open a case
-                if (newValue != null) {
-                    DateSearchFilter.this.updateTimeZoneList();
-                }
-            }
-
-            // if the image is added to the case
-            if (changed.equals(Case.Events.DATA_SOURCE_ADDED.toString())) {
-                DateSearchFilter.this.updateTimeZoneList();
-            }
-
-            // if the image is removed from the case
-            if (changed.equals(Case.Events.DATA_SOURCE_DELETED.toString())) {
-                DateSearchFilter.this.updateTimeZoneList();
-            }
+            switch (Case.Events.valueOf(evt.getPropertyName())) {
+                case CURRENT_CASE:
+                    Object newValue = evt.getNewValue();
+                    if (null == newValue) {
+                        /**
+                         * Closing a case. Nothing to do.
+                         */
+                        break;
+                    }
+                    /**
+                     * Else opening a case, fall through.
+                     */
+                case DATA_SOURCE_ADDED:
+                case DATA_SOURCE_DELETED:
+                  SwingUtilities.invokeLater(new Runnable() {
+                        @Override
+                        public void run() {
+                            DateSearchFilter.this.updateTimeZoneList();
+                        }
+                    });            
+                    break;
+            }            
         }
     }
 }

--- a/Core/src/org/sleuthkit/autopsy/timeline/TimeLineController.java
+++ b/Core/src/org/sleuthkit/autopsy/timeline/TimeLineController.java
@@ -1,7 +1,7 @@
 /*
  * Autopsy Forensic Browser
  *
- * Copyright 2014 Basis Technology Corp.
+ * Copyright 2014-2015 Basis Technology Corp.
  * Contact: carrier <at> sleuthkit <dot> org
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -58,7 +58,6 @@ import org.joda.time.Interval;
 import org.joda.time.ReadablePeriod;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
-import org.openide.util.Exceptions;
 import org.openide.util.NbBundle;
 import org.openide.windows.WindowManager;
 import org.sleuthkit.autopsy.casemodule.Case;
@@ -81,7 +80,8 @@ import org.sleuthkit.datamodel.SleuthkitCase;
 import org.sleuthkit.datamodel.SleuthkitCase.CaseDbQuery;
 import org.sleuthkit.datamodel.TskCoreException;
 
-/** Controller in the MVC design along with model = {@link FilteredEventsModel}
+/**
+ * Controller in the MVC design along with model = {@link FilteredEventsModel}
  * and views = {@link TimeLineView}. Forwards interpreted user gestures form
  * views to model. Provides model to view. Is entry point for timeline module.
  *
@@ -100,7 +100,7 @@ public class TimeLineController {
     private static final Logger LOGGER = Logger.getLogger(TimeLineController.class.getName());
 
     private static final String DO_REPOPULATE_MESSAGE = NbBundle.getMessage(TimeLineController.class,
-                                                                            "Timeline.do_repopulate.msg");
+            "Timeline.do_repopulate.msg");
 
     private static final ReadOnlyObjectWrapper<TimeZone> timeZone = new ReadOnlyObjectWrapper<>(TimeZone.getDefault());
 
@@ -234,7 +234,9 @@ public class TimeLineController {
         caseListener = new AutopsyCaseListener();
     }
 
-    /** @return a shared events model */
+    /**
+     * @return a shared events model
+     */
     public FilteredEventsModel getEventsModel() {
         return filteredEvents;
     }
@@ -312,7 +314,9 @@ public class TimeLineController {
         }
     }
 
-    /** show the timeline window and prompt for rebuilding database */
+    /**
+     * show the timeline window and prompt for rebuilding database
+     */
     synchronized void openTimeLine() {
 
         // listen for case changes (specifically images being added, and case changes).
@@ -359,7 +363,7 @@ public class TimeLineController {
     private long getCaseLastArtifactID(final SleuthkitCase sleuthkitCase) {
         long caseLastArtfId = -1;
         String query = "select Max(artifact_id) as max_id from blackboard_artifacts"; // NON-NLS
-        
+
         try (CaseDbQuery dbQuery = sleuthkitCase.executeQuery(query)) {
             ResultSet resultSet = dbQuery.getResultSet();
             while (resultSet.next()) {
@@ -481,12 +485,12 @@ public class TimeLineController {
         if (newLOD == DescriptionLOD.FULL && count > 10_000) {
 
             int showConfirmDialog = JOptionPane.showConfirmDialog(mainFrame,
-                                                                  NbBundle.getMessage(this.getClass(),
-                                                                                      "Timeline.pushDescrLOD.confdlg.msg",
-                                                                                      NumberFormat.getInstance().format(count)),
-                                                                  NbBundle.getMessage(TimeLineTopComponent.class,
-                                                                                      "Timeline.pushDescrLOD.confdlg.details"),
-                                                                  JOptionPane.YES_NO_OPTION);
+                    NbBundle.getMessage(this.getClass(),
+                            "Timeline.pushDescrLOD.confdlg.msg",
+                            NumberFormat.getInstance().format(count)),
+                    NbBundle.getMessage(TimeLineTopComponent.class,
+                            "Timeline.pushDescrLOD.confdlg.details"),
+                    JOptionPane.YES_NO_OPTION);
 
             shouldContinue = (showConfirmDialog == JOptionPane.YES_OPTION);
         }
@@ -634,7 +638,7 @@ public class TimeLineController {
         return JOptionPane.showConfirmDialog(mainFrame,
                 DO_REPOPULATE_MESSAGE,
                 NbBundle.getMessage(TimeLineTopComponent.class,
-                                    "Timeline.showLastPopulatedWhileIngestingConf.confDlg.details"),
+                        "Timeline.showLastPopulatedWhileIngestingConf.confDlg.details"),
                 JOptionPane.YES_NO_OPTION,
                 JOptionPane.QUESTION_MESSAGE);
 
@@ -663,17 +667,7 @@ public class TimeLineController {
         @Override
         public void propertyChange(PropertyChangeEvent evt) {
             switch (IngestManager.IngestModuleEvent.valueOf(evt.getPropertyName())) {
-                case CONTENT_CHANGED:
-//                    ((ModuleContentEvent)evt.getOldValue())????
-                    //ModuleContentEvent doesn't seem to provide any usefull information...
-                    break;
-                case DATA_ADDED:
-//                    Collection<BlackboardArtifact> artifacts = ((ModuleDataEvent) evt.getOldValue()).getArtifacts();
-                    //new artifacts, insert them into db
-                    break;
                 case FILE_DONE:
-//                    Long fileID = (Long) evt.getOldValue();
-                    //update file (known status) for file with id
                     Platform.runLater(() -> {
                         newEventsFlag.set(true);
                     });
@@ -690,8 +684,12 @@ public class TimeLineController {
             switch (IngestManager.IngestJobEvent.valueOf(evt.getPropertyName())) {
                 case CANCELLED:
                 case COMPLETED:
-                    //if we are doing incremental updates, drop this
-                    outOfDatePromptAndRebuild();
+                    SwingUtilities.invokeLater(new Runnable() {
+                        @Override
+                        public void run() {
+                            outOfDatePromptAndRebuild();
+                        }
+                    });
                     break;
             }
         }
@@ -704,13 +702,21 @@ public class TimeLineController {
         public void propertyChange(PropertyChangeEvent evt) {
             switch (Case.Events.valueOf(evt.getPropertyName())) {
                 case DATA_SOURCE_ADDED:
-//                    Content content = (Content) evt.getNewValue();
-                    //if we are doing incremental updates, drop this
-                    outOfDatePromptAndRebuild();
+                    SwingUtilities.invokeLater(new Runnable() {
+                        @Override
+                        public void run() {
+                            outOfDatePromptAndRebuild();
+                        }
+                    });
                     break;
                 case CURRENT_CASE:
-                    OpenTimelineAction.invalidateController();
-                    closeTimeLine();
+                    SwingUtilities.invokeLater(new Runnable() {
+                        @Override
+                        public void run() {
+                            OpenTimelineAction.invalidateController();
+                            closeTimeLine();
+                        }
+                    });
                     break;
             }
         }


### PR DESCRIPTION
- Makes TimelineController and DataSearchFilter do UI updates in EDT now that their propertyChange() implementations can be called from a JMS thread.
- Updates IDE formatting for TimelineController.
- Removes dead code and fixes some weaknesses flagged by the IDE in DirectoryTreeTopComponent and TimelineController.