### PR TITLE
Fix warning in DateSearchFilter, do some member ref/lamda conversions

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/directorytree/DirectoryTreeTopComponent.java
+++ b/Core/src/org/sleuthkit/autopsy/directorytree/DirectoryTreeTopComponent.java
@@ -537,67 +537,43 @@ public final class DirectoryTreeTopComponent extends TopComponent implements Dat
             // data model objects when a case is closed.
             if (oldValue != null && newValue == null) {
                 // The current case has been closed. Reset the ExplorerManager.
-                SwingUtilities.invokeLater(new Runnable() {
-                    @Override
-                    public void run() {
-                        Node emptyNode = new AbstractNode(Children.LEAF);
-                        em.setRootContext(emptyNode);
-                    }
+                SwingUtilities.invokeLater(() -> {
+                    Node emptyNode = new AbstractNode(Children.LEAF);
+                    em.setRootContext(emptyNode);
                 });
             } else if (newValue != null) {
                 // A new case has been opened. Reset the ExplorerManager. 
                 Case newCase = (Case) newValue;
                 final String newCaseName = newCase.getName();
-                SwingUtilities.invokeLater(new Runnable() {
-                    @Override
-                    public void run() {
-                        em.getRootContext().setName(newCaseName);
-                        em.getRootContext().setDisplayName(newCaseName);
+                SwingUtilities.invokeLater(() -> {
+                    em.getRootContext().setName(newCaseName);
+                    em.getRootContext().setDisplayName(newCaseName);
 
-                        // Reset the forward and back 
-                        // buttons. Note that a call to CoreComponentControl.openCoreWindows()
-                        // by the new Case object will lead to a componentOpened() call
-                        // that will repopulate the tree.
-                        // @@@ The repopulation of the tree in this fashion also merits
-                        // reconsideration.
-                        resetHistory();
-                    }
+                    // Reset the forward and back
+                    // buttons. Note that a call to CoreComponentControl.openCoreWindows()
+                    // by the new Case object will lead to a componentOpened() call
+                    // that will repopulate the tree.
+                    // @@@ The repopulation of the tree in this fashion also merits
+                    // reconsideration.
+                    resetHistory();
                 });
             }
         } // if the image is added to the case
         else if (changed.equals(Case.Events.DATA_SOURCE_ADDED.toString())) {
-            SwingUtilities.invokeLater(new Runnable() {
-                @Override
-                public void run() {
-                    componentOpened();
-                }
-            });
+            SwingUtilities.invokeLater(this::componentOpened);
         } // change in node selection
         else if (changed.equals(ExplorerManager.PROP_SELECTED_NODES)) {
-            SwingUtilities.invokeLater(new Runnable() {
-                @Override
-                public void run() {
-                    respondSelection((Node[]) oldValue, (Node[]) newValue);
-                }
+            SwingUtilities.invokeLater(() -> {
+                respondSelection((Node[]) oldValue, (Node[]) newValue);
             });
         } else if (changed.equals(IngestManager.IngestModuleEvent.DATA_ADDED.toString())) {
             // nothing to do here.
             // all nodes should be listening for these events and update accordingly.
         } else if (changed.equals(IngestManager.IngestJobEvent.COMPLETED.toString())
                 || changed.equals(IngestManager.IngestJobEvent.CANCELLED.toString())) {
-            SwingUtilities.invokeLater(new Runnable() {
-                @Override
-                public void run() {
-                    refreshDataSourceTree();
-                }
-            });
+            SwingUtilities.invokeLater(this::refreshDataSourceTree);
         } else if (changed.equals(IngestManager.IngestModuleEvent.CONTENT_CHANGED.toString())) {
-            SwingUtilities.invokeLater(new Runnable() {
-                @Override
-                public void run() {
-                    refreshDataSourceTree();
-                }
-            });
+            SwingUtilities.invokeLater(this::refreshDataSourceTree);
         }
     }
 

--- a/Core/src/org/sleuthkit/autopsy/filesearch/DateSearchFilter.java
+++ b/Core/src/org/sleuthkit/autopsy/filesearch/DateSearchFilter.java
@@ -44,6 +44,7 @@ import org.sleuthkit.autopsy.casemodule.Case;
 
 /**
  * Filters file date properties (modified/created/etc.. times)
+ *
  * @author pmartel
  */
 class DateSearchFilter extends AbstractFileSearchFilter<DateSearchPanel> {
@@ -123,7 +124,6 @@ class DateSearchFilter extends AbstractFileSearchFilter<DateSearchPanel> {
         final boolean changedChecked = panel.getChangedCheckBox().isSelected();
         final boolean accessedChecked = panel.getAccessedCheckBox().isSelected();
         final boolean createdChecked = panel.getAccessedCheckBox().isSelected();
-
 
         if (modifiedChecked || changedChecked || accessedChecked || createdChecked) {
 
@@ -240,25 +240,18 @@ class DateSearchFilter extends AbstractFileSearchFilter<DateSearchPanel> {
             switch (Case.Events.valueOf(evt.getPropertyName())) {
                 case CURRENT_CASE:
                     Object newValue = evt.getNewValue();
-                    if (null == newValue) {
+                    if (null != newValue) {
                         /**
-                         * Closing a case. Nothing to do.
+                         * Opening a new case.
                          */
-                        break;
+                        SwingUtilities.invokeLater(DateSearchFilter.this::updateTimeZoneList);
                     }
-                    /**
-                     * Else opening a case, fall through.
-                     */
+                    break;
                 case DATA_SOURCE_ADDED:
                 case DATA_SOURCE_DELETED:
-                  SwingUtilities.invokeLater(new Runnable() {
-                        @Override
-                        public void run() {
-                            DateSearchFilter.this.updateTimeZoneList();
-                        }
-                    });            
+                    SwingUtilities.invokeLater(DateSearchFilter.this::updateTimeZoneList);
                     break;
-            }            
+            }
         }
     }
 }

--- a/Core/src/org/sleuthkit/autopsy/timeline/TimeLineController.java
+++ b/Core/src/org/sleuthkit/autopsy/timeline/TimeLineController.java
@@ -684,11 +684,8 @@ public class TimeLineController {
             switch (IngestManager.IngestJobEvent.valueOf(evt.getPropertyName())) {
                 case CANCELLED:
                 case COMPLETED:
-                    SwingUtilities.invokeLater(new Runnable() {
-                        @Override
-                        public void run() {
-                            outOfDatePromptAndRebuild();
-                        }
+                    SwingUtilities.invokeLater(() -> {
+                        outOfDatePromptAndRebuild();
                     });
                     break;
             }
@@ -702,20 +699,14 @@ public class TimeLineController {
         public void propertyChange(PropertyChangeEvent evt) {
             switch (Case.Events.valueOf(evt.getPropertyName())) {
                 case DATA_SOURCE_ADDED:
-                    SwingUtilities.invokeLater(new Runnable() {
-                        @Override
-                        public void run() {
-                            outOfDatePromptAndRebuild();
-                        }
+                    SwingUtilities.invokeLater(() -> {
+                        outOfDatePromptAndRebuild();
                     });
                     break;
                 case CURRENT_CASE:
-                    SwingUtilities.invokeLater(new Runnable() {
-                        @Override
-                        public void run() {
-                            OpenTimelineAction.invalidateController();
-                            closeTimeLine();
-                        }
+                    SwingUtilities.invokeLater(() -> {
+                        OpenTimelineAction.invalidateController();
+                        closeTimeLine();
                     });
                     break;
             }


### PR DESCRIPTION
- Fix warning for fall through in DateSearchFilter class
- Convert anonymous inner classes to member reference invocations and lambdas in DirectoryTreeTopComponent, TimelineController, and DateSearchFilter. 