### PR TITLE
Various Image Gallery performance improvements.

### DIFF
--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/ImageGalleryController.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/ImageGalleryController.java
@@ -357,6 +357,7 @@ public final class ImageGalleryController {
         Platform.runLater(() -> {
             historyManager.clear();
         });
+        Category.clearTagNames();
 
         Toolbar.getDefault().reset();
         groupManager.clear();

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/TagUtils.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/TagUtils.java
@@ -20,7 +20,9 @@ package org.sleuthkit.autopsy.imagegallery;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
@@ -92,10 +94,12 @@ public class TagUtils {
     }
 
     public static void fireChange(Collection<Long> ids) {
+        Set<TagUtils.TagListener> listenersCopy = new HashSet<TagUtils.TagListener>(listeners);
         synchronized (listeners) {
-            for (TagListener list : listeners) {
-                list.handleTagsChanged(ids);
-            }
+            listenersCopy.addAll(listeners);
+        }
+        for (TagListener list : listenersCopy) {
+            list.handleTagsChanged(ids);
         }
     }
 

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/actions/AddDrawableTagAction.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/actions/AddDrawableTagAction.java
@@ -75,7 +75,11 @@ public class AddDrawableTagAction extends AddTagAction {
     @Override
     public void addTag(TagName tagName, String comment) {
         Set<Long> selectedFiles = new HashSet<>(FileIDSelectionModel.getInstance().getSelected());
+        addTagsToFiles(tagName, comment, selectedFiles);
+    }
         
+    @Override
+    public void addTagsToFiles(TagName tagName, String comment, Set<Long> selectedFiles){    
         new SwingWorker<Void, Void>() {
             
             @Override

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/actions/AddTagAction.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/actions/AddTagAction.java
@@ -21,6 +21,7 @@ package org.sleuthkit.autopsy.imagegallery.actions;
 import org.sleuthkit.autopsy.imagegallery.datamodel.Category;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
 import javafx.event.ActionEvent;
 import javafx.scene.control.Menu;
@@ -65,6 +66,12 @@ abstract class AddTagAction {
      * comment to one or more a SleuthKit data model objects.
      */
     abstract protected void addTag(TagName tagName, String comment);
+    
+    /**
+     * Template method to allow derived classes to add the indicated tag and
+     * comment to a list of one or more file IDs.
+     */
+    abstract protected void addTagsToFiles(TagName tagName, String comment, Set<Long> selectedFiles);    
 
     /**
      * Instances of this class implement a context menu user interface for

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/actions/CategorizeAction.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/actions/CategorizeAction.java
@@ -72,7 +72,11 @@ public class CategorizeAction extends AddTagAction {
     @Override
     public void addTag(TagName tagName, String comment) {
         Set<Long> selectedFiles = new HashSet<>(FileIDSelectionModel.getInstance().getSelected());
-
+        addTagsToFiles(tagName, comment, selectedFiles);
+    }
+      
+    @Override
+    public void addTagsToFiles(TagName tagName, String comment, Set<Long> selectedFiles){    
         //TODO: should this get submitted to controller rather than a swingworker ? -jm
         new SwingWorker<Object, Object>() {
 
@@ -97,9 +101,11 @@ public class CategorizeAction extends AddTagAction {
                             if (ct.getName().getDisplayName().startsWith(Category.CATEGORY_PREFIX)) {
                                 LOGGER.log(Level.INFO, "removing old category from {0}", file.getName());
                                 Case.getCurrentCase().getServices().getTagsManager().deleteContentTag(ct);
+                                controller.getDatabase().decrementCategoryCount(Category.fromDisplayName(ct.getName().getDisplayName()));
                             }
                         }
 
+                        controller.getDatabase().incrementCategoryCount(Category.fromDisplayName(tagName.getDisplayName()));
                         if (tagName != Category.ZERO.getTagName()) { // no tags for cat-0
                             Case.getCurrentCase().getServices().getTagsManager().addContentTag(file, tagName, comment);
                         }

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/Category.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/Category.java
@@ -66,11 +66,14 @@ public enum Category implements Comparable<Category> {
     private final static Set<CategoryListener> listeners = new HashSet<>();
 
     public static void fireChange(Collection<Long> ids) {
+        Set<CategoryListener> listenersCopy = new HashSet<CategoryListener>(listeners);
         synchronized (listeners) {
-            for (CategoryListener list : listeners) {
-                list.handleCategoryChanged(ids);
-            }
+            listenersCopy.addAll(listeners);
         }
+        for (CategoryListener list : listenersCopy) {
+            list.handleCategoryChanged(ids);
+        }
+      
     }
 
     public static void registerListener(CategoryListener aThis) {

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/Category.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/Category.java
@@ -153,6 +153,18 @@ public enum Category implements Comparable<Category> {
         });
         return menuItem;
     }
+    
+    /**
+     * Use when closing a case to make sure everything is re-initialized in the next case.
+     */
+    public static void clearTagNames(){
+        Category.ZERO.tagName = null;
+        Category.ONE.tagName = null;
+        Category.TWO.tagName = null;
+        Category.THREE.tagName = null;
+        Category.FOUR.tagName = null;
+        Category.FIVE.tagName = null;
+    }
 
     public static interface CategoryListener {
 

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/DrawableFile.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/DrawableFile.java
@@ -67,6 +67,17 @@ public abstract class DrawableFile<T extends AbstractFile> extends AbstractFile 
             return new ImageFile<>(abstractFileById, analyzed);
         }
     }
+    
+    /**
+     * Skip the database query if we have already determined the file type.
+     */
+    public static DrawableFile<?> create(AbstractFile abstractFileById, boolean analyzed, boolean isVideo) {
+        if (isVideo) {
+            return new VideoFile<>(abstractFileById, analyzed);
+        } else {
+            return new ImageFile<>(abstractFileById, analyzed);
+        }
+    }    
 
     public static DrawableFile<?> create(Long id, boolean analyzed) throws TskCoreException, IllegalStateException {
 

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/grouping/GroupManager.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/grouping/GroupManager.java
@@ -531,42 +531,7 @@ public class GroupManager implements FileUpdateEvent.FileUpdateListener {
      * @throws TskCoreException 
      */
     public int countFilesWithCategory(Category category) throws TskCoreException {
-        try {
-            if (category == Category.ZERO) {
-
-                // It is unlikely that Category Zero (Uncategorized) files will be tagged as such - 
-                // this is really just the default setting. So we count the number of files
-                // tagged with the other categories and subtract from the total.
-                int allOtherCatCount = 0;
-                TagName[] tns = {Category.FOUR.getTagName(), Category.THREE.getTagName(), Category.TWO.getTagName(), Category.ONE.getTagName(), Category.FIVE.getTagName()};
-                for (TagName tn : tns) {
-                    List<ContentTag> contentTags = Case.getCurrentCase().getServices().getTagsManager().getContentTagsByTagName(tn);
-                    for (ContentTag ct : contentTags) {
-                        if (ct.getContent() instanceof AbstractFile && ImageGalleryModule.isSupportedAndNotKnown((AbstractFile) ct.getContent())) {
-                            allOtherCatCount++;
-                        }
-                    }
-                }
-                return (db.countAllFiles() - allOtherCatCount);
-            } else {
-
-                int fileCount = 0;
-                List<ContentTag> contentTags = Case.getCurrentCase().getServices().getTagsManager().getContentTagsByTagName(category.getTagName());
-                for (ContentTag ct : contentTags) {
-                    if (ct.getContent() instanceof AbstractFile && ImageGalleryModule.isSupportedAndNotKnown((AbstractFile) ct.getContent())) {
-                        fileCount++;
-                    }
-                }
-
-                return fileCount;
-            }
-        } catch (TskCoreException ex) {
-            LOGGER.log(Level.WARNING, "TSK error getting files in Category:" + category.getDisplayName(), ex);
-            throw ex;
-        } catch(IllegalStateException ex){
-            throw new TskCoreException("Case closed while getting files");
-        }
-    
+        return db.getCategoryCount(category);
     }
 
     public List<Long> getFileIDsWithTag(TagName tagName) throws TskCoreException {
@@ -738,6 +703,7 @@ public class GroupManager implements FileUpdateEvent.FileUpdateListener {
                     TagUtils.fireChange(fileIDs);
                 }
                 break;
+            
         }
     }
 

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/gui/GroupPane.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/gui/GroupPane.java
@@ -22,6 +22,8 @@ import com.google.common.collect.ImmutableMap;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Set;
+import java.util.HashSet;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -277,8 +279,8 @@ public class GroupPane extends BorderPane implements GroupView {
         menuItem.setOnAction(new EventHandler<ActionEvent>() {
             @Override
             public void handle(ActionEvent t) {
-                selectAllFiles();
-                new CategorizeAction().addTag(cat.getTagName(), "");
+                Set<Long> fileIdSet = new HashSet<Long>(getGrouping().fileIds());
+                new CategorizeAction().addTagsToFiles(cat.getTagName(), "", fileIdSet);
 
                 grpCatSplitMenu.setText(cat.getDisplayName());
                 grpCatSplitMenu.setOnAction(this);
@@ -292,8 +294,8 @@ public class GroupPane extends BorderPane implements GroupView {
         menuItem.setOnAction(new EventHandler<ActionEvent>() {
             @Override
             public void handle(ActionEvent t) {
-                selectAllFiles();
-                AddDrawableTagAction.getInstance().addTag(tn, "");
+                Set<Long> fileIdSet = new HashSet<Long>(getGrouping().fileIds());
+                AddDrawableTagAction.getInstance().addTagsToFiles(tn, "", fileIdSet);
 
                 grpTagSplitMenu.setText(tn.getDisplayName());
                 grpTagSplitMenu.setOnAction(this);


### PR DESCRIPTION
- Keep some file data in memory to avoid excessive database queries (list of image file IDs, image/video, and category counts)
- When categorizing/tagging a group, don't create tiles (including thumbnails) for images that aren't on the screen
- Changed locking around Category and Tag listeners to prevent slowdown/deadlocks