### PR TITLE
NPE in case of removed photorec carver job handled

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/modules/photoreccarver/PhotoRecCarverFileIngestModule.java
+++ b/Core/src/org/sleuthkit/autopsy/modules/photoreccarver/PhotoRecCarverFileIngestModule.java
@@ -239,7 +239,7 @@ final class PhotoRecCarverFileIngestModule implements FileIngestModule {
      */
     @Override
     public void shutDown() {
-        if (refCounter.decrementAndGet(this.context.getJobId()) == 0) {
+        if (this.context != null && refCounter.decrementAndGet(this.context.getJobId()) == 0) {
             try {
                 // The last instance of this module for an ingest job cleans out 
                 // the working paths map entry for the job and deletes the temp dir.


### PR DESCRIPTION
context = null when context.processingUnallocatedSpace() is set false and Photorec Carver module is run.