### PR TITLE
Return immediately after indexing unallocated space, otherwise it get…

### DIFF
--- a/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/KeywordSearchIngestModule.java
+++ b/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/KeywordSearchIngestModule.java
@@ -454,6 +454,7 @@ public final class KeywordSearchIngestModule implements FileIngestModule {
             // unallocated and unused blocks can only have strings extracted from them. 
             if ((aType.equals(TskData.TSK_DB_FILES_TYPE_ENUM.UNALLOC_BLOCKS) || aType.equals(TskData.TSK_DB_FILES_TYPE_ENUM.UNUSED_BLOCKS))) {
                 extractStringsAndIndex(aFile);
+                return;
             }
 
             final long size = aFile.getSize();


### PR DESCRIPTION
…s processed twice.