### PR TITLE
fix small error (inverted logic)

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/examples/SampleFileIngestModule.java
+++ b/Core/src/org/sleuthkit/autopsy/examples/SampleFileIngestModule.java
@@ -98,7 +98,7 @@ class SampleFileIngestModule implements FileIngestModule {
 
     @Override
     public IngestModule.ProcessResult process(AbstractFile file) {
-        if (attrId != -1) {
+        if (attrId == -1) {
             return IngestModule.ProcessResult.ERROR;
         }
 


### PR DESCRIPTION
obvious error that prevents process() from running in the normal case;
could be confusing to newcomers (which is who examples are really aimed toward)