### PR TITLE
reduce size of free space required for carving, as the file is alread…

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/modules/photoreccarver/Bundle.properties
+++ b/Core/src/org/sleuthkit/autopsy/modules/photoreccarver/Bundle.properties
@@ -12,3 +12,5 @@ cannotRunExecutable.message=Unable to execute unallocated carver
 cannotCreateOutputDir.message=Unable to create output directory: {0}
 PhotoRecIngestModule.processTerminated=PhotoRec Carver ingest module was terminated due to exceeding max allowable run time when scanning 
 PhotoRecIngestModule.moduleError=PhotoRec Carver Module Error
+PhotoRecIngestModule.UnableToCarve=Unable to carve with PhotoRec
+PhotoRecIngestModule.NotEnoughDiskSpace=Not enough disk space to carve files. Carving will be skipped.

--- a/Core/src/org/sleuthkit/autopsy/modules/photoreccarver/PhotoRecCarverFileIngestModule.java
+++ b/Core/src/org/sleuthkit/autopsy/modules/photoreccarver/PhotoRecCarverFileIngestModule.java
@@ -147,9 +147,11 @@ final class PhotoRecCarverFileIngestModule implements FileIngestModule {
             // Some network drives always return -1 for free disk space. 
             // In this case, expect enough space and move on.
             long freeDiskSpace = IngestServices.getInstance().getFreeDiskSpace();
-            if ((freeDiskSpace!=-1) && ((file.getSize() * 2) > freeDiskSpace)) {
+            if ((freeDiskSpace != -1) && ((file.getSize() * 1.2) > freeDiskSpace)) {
                 logger.log(Level.SEVERE, "PhotoRec error processing {0} with {1} Not enough space on primary disk to carve unallocated space.", // NON-NLS
                         new Object[]{file.getName(), PhotoRecCarverIngestModuleFactory.getModuleName()}); // NON-NLS
+                MessageNotifyUtil.Notify.error(NbBundle.getMessage(PhotoRecCarverFileIngestModule.class, "PhotoRecIngestModule.UnableToCarve"),
+                        NbBundle.getMessage(PhotoRecCarverFileIngestModule.class, "PhotoRecIngestModule.NotEnoughDiskSpace"));
                 return IngestModule.ProcessResult.ERROR;
             }
 


### PR DESCRIPTION
…y copied to the drive, we don't need 2x. Also warn the user if carving doesn't occur because of lack of disk space.