### PR TITLE
Solr document ids can now contain artifact ids which start at LONG.MI…

### DIFF
--- a/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/LuceneQuery.java
+++ b/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/LuceneQuery.java
@@ -494,9 +494,9 @@ class LuceneQuery implements KeywordSearchQuery {
                 rightID = rightID.substring(0, index);
             }
             
-            Integer leftInt = new Integer(leftID);
-            Integer rightInt = new Integer(rightID);
-            return leftInt.compareTo(rightInt);
+            Long leftLong = new Long(leftID);
+            Long rightLong = new Long(rightID);
+            return leftLong.compareTo(rightLong);
         }
     }
     


### PR DESCRIPTION
…N_VALUE (-9223372036854775808) which is outside Integer range so we need to use Long instead of Integer when comparing document ids.