### PR TITLE
jython moduleName getting regex fixed

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/python/JythonModuleLoader.java
+++ b/Core/src/org/sleuthkit/autopsy/python/JythonModuleLoader.java
@@ -120,7 +120,7 @@ public final class JythonModuleLoader {
         interpreter.exec("import sys"); //NON-NLS
         String path = Matcher.quoteReplacement(script.getParent());
         interpreter.exec("sys.path.append('" + path + "')"); //NON-NLS
-        String moduleName = script.getName().replaceAll(".py", ""); //NON-NLS
+        String moduleName = script.getName().replaceAll("\\.py$", ""); //NON-NLS
 
         // reload the module so that the changes made to it can be loaded.
         interpreter.exec("import " + moduleName); //NON-NLS


### PR DESCRIPTION
Replace last occurrence of ".py" in a file name instead of any occurrence of ".py" in the file name.