### PR TITLE
Updated ChildFactory.createKeys() implementations to not return false…

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/datamodel/ExtractedContent.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/ExtractedContent.java
@@ -210,33 +210,31 @@ public class ExtractedContent implements AutopsyVisitableItem {
 
         @Override
         protected boolean createKeys(List<BlackboardArtifact.ARTIFACT_TYPE> list) {
-            if (skCase == null) {
-                return false;
-            }
-            
-            try {
-                List<BlackboardArtifact.ARTIFACT_TYPE> inUse = skCase.getBlackboardArtifactTypesInUse();
-                inUse.removeAll(doNotShow);
-                Collections.sort(inUse,
-                        new Comparator<BlackboardArtifact.ARTIFACT_TYPE>() {
-                    @Override
-                    public int compare(BlackboardArtifact.ARTIFACT_TYPE a, BlackboardArtifact.ARTIFACT_TYPE b) {
-                        return a.getDisplayName().compareTo(b.getDisplayName());
-                    }
-                });
-                list.addAll(inUse);
 
-                // the create node method will get called only for new types
-                // refresh the counts if we already created them from a previous update
-                for (BlackboardArtifact.ARTIFACT_TYPE art : inUse) {
-                    TypeNode node = typeNodeList.get(art);
-                    if (node != null) {
-                        node.updateDisplayName();
+            if (skCase != null) {
+                try {
+                    List<BlackboardArtifact.ARTIFACT_TYPE> inUse = skCase.getBlackboardArtifactTypesInUse();
+                    inUse.removeAll(doNotShow);
+                    Collections.sort(inUse,
+                            new Comparator<BlackboardArtifact.ARTIFACT_TYPE>() {
+                        @Override
+                        public int compare(BlackboardArtifact.ARTIFACT_TYPE a, BlackboardArtifact.ARTIFACT_TYPE b) {
+                            return a.getDisplayName().compareTo(b.getDisplayName());
+                        }
+                    });
+                    list.addAll(inUse);
+
+                    // the create node method will get called only for new types
+                    // refresh the counts if we already created them from a previous update
+                    for (BlackboardArtifact.ARTIFACT_TYPE art : inUse) {
+                        TypeNode node = typeNodeList.get(art);
+                        if (node != null) {
+                            node.updateDisplayName();
+                        }
                     }
+                } catch (TskCoreException ex) {
+                    Logger.getLogger(TypeFactory.class.getName()).log(Level.SEVERE, "Error getting list of artifacts in use: " + ex.getLocalizedMessage()); //NON-NLS
                 }
-            } catch (TskCoreException ex) {
-                Logger.getLogger(TypeFactory.class.getName()).log(Level.SEVERE, "Error getting list of artifacts in use: " + ex.getLocalizedMessage()); //NON-NLS
-                return false;
             }
             return true;
         }
@@ -446,15 +444,14 @@ public class ExtractedContent implements AutopsyVisitableItem {
 
         @Override
         protected boolean createKeys(List<BlackboardArtifact> list) {
-            if (skCase == null) {
-                return false;
-            }
             
-            try {
-                List<BlackboardArtifact> arts = skCase.getBlackboardArtifacts(type.getTypeID());
-                list.addAll(arts);
-            } catch (TskException ex) {
-                Logger.getLogger(ArtifactFactory.class.getName()).log(Level.SEVERE, "Couldn't get blackboard artifacts from database", ex); //NON-NLS
+            if (skCase != null) {
+                try {
+                    List<BlackboardArtifact> arts = skCase.getBlackboardArtifacts(type.getTypeID());
+                    list.addAll(arts);
+                } catch (TskException ex) {
+                    Logger.getLogger(ArtifactFactory.class.getName()).log(Level.SEVERE, "Couldn't get blackboard artifacts from database", ex); //NON-NLS
+                }
             }
             return true;
         }

--- a/Core/src/org/sleuthkit/autopsy/datamodel/FileSize.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/FileSize.java
@@ -363,11 +363,7 @@ public class FileSize implements AutopsyVisitableItem {
 
             @Override
             protected boolean createKeys(List<AbstractFile> list) {
-                List<AbstractFile> l = runFsQuery();
-                if (l == null) {
-                    return false;
-                }
-                list.addAll(l);
+                list.addAll(runFsQuery());
                 return true;
             }
 
@@ -386,8 +382,7 @@ public class FileSize implements AutopsyVisitableItem {
                         break;
 
                     default:
-                        logger.log(Level.SEVERE, "Unsupported filter type to get files by size: {0}", filter); //NON-NLS
-                        return null;
+                        throw new IllegalArgumentException("Unsupported filter type to get files by size: " + filter); //NON-NLS
                 }
                 // ignore unalloc block files
                 query = query + " AND (type != " + TskData.TSK_DB_FILES_TYPE_ENUM.UNALLOC_BLOCKS.getFileType() + ")"; //NON-NLS
@@ -398,19 +393,15 @@ public class FileSize implements AutopsyVisitableItem {
             private List<AbstractFile> runFsQuery() {
                 List<AbstractFile> ret = new ArrayList<>();
 
-                String query = makeQuery(filter);
-                if (query == null) {
-                    return null;
-                }
-
                 try {
+                    String query = makeQuery(filter);
+
                     ret = skCase.findAllFilesWhere(query);
-                } catch (TskCoreException e) {
-                    logger.log(Level.SEVERE, "Error getting files for the file size view using: " + query, e); //NON-NLS
+                } catch (Exception e) {
+                    logger.log(Level.SEVERE, "Error getting files for the file size view: " + e.getMessage()); //NON-NLS
                 }
 
                 return ret;
-
             }
 
             /**


### PR DESCRIPTION
… when they are unable to create keys. Returning false means "the list has only been partially populated and this method should be called again to batch more keys".