### PR TITLE
NPE and other runtime exceptions possibly thrown handled

### DIFF
--- a/thunderbirdparser/src/org/sleuthkit/autopsy/thunderbirdparser/MboxParser.java
+++ b/thunderbirdparser/src/org/sleuthkit/autopsy/thunderbirdparser/MboxParser.java
@@ -136,7 +136,7 @@ import org.sleuthkit.autopsy.ingest.IngestServices;
             try {
                 Message msg = messageBuilder.parseMessage(message.asInputStream(theEncoder.charset()));
                 emails.add(extractEmail(msg));
-            } catch (IOException ex) {
+            } catch (RuntimeException | IOException ex) {
                 logger.log(Level.WARNING, "Failed to get message from mbox: {0}", ex.getMessage()); //NON-NLS
                 failCount++;
             }


### PR DESCRIPTION
NPE thrown in case of invalid message format.