### PR TITLE
ignore registry data types which yield no interesting artifacts

### DIFF
--- a/RecentActivity/src/org/sleuthkit/autopsy/recentactivity/ExtractRegistry.java
+++ b/RecentActivity/src/org/sleuthkit/autopsy/recentactivity/ExtractRegistry.java
@@ -649,7 +649,6 @@ class ExtractRegistry extends Extract {
                                     break;
 
                                 default:
-                                    logger.log(Level.WARNING, "Unrecognized node name: {0}", dataType); //NON-NLS
                                     break;
                             }
                         }


### PR DESCRIPTION
shellfolders (and other such registry datatypes) contain no useful information.
Avoid logging such unrecognized nodes.