### PR TITLE
Revert "invalid utf-8 data sanitized before feeding to the Solr Inges…

### DIFF
--- a/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/Bundle.properties
+++ b/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/Bundle.properties
@@ -157,7 +157,6 @@ DropdownSearchPanel.selectAllMenuItem.text=Select All
 DropdownSearchPanel.pasteMenuItem.text=Paste
 DropdownSearchPanel.copyMenuItem.text=Copy
 AbstractFileChunk.index.exception.msg=Problem ingesting file string chunk\: {0}, chunk\: {1}
-AbstractFileChunk.index.charCodingException.msg=Could not sanitize the content of the file: {0}
 AbstractFileStringContentStream.getSize.exception.msg=Cannot tell how many chars in converted string, until entire string is converted
 AbstractFileStringContentStream.getSrcInfo.text=File\:{0}
 ByteContentStream.getSrcInfo.text=File\:{0}


### PR DESCRIPTION
Reverts sleuthkit/autopsy#1463. We need to back this out until issues involving exhaustion of heap memory are resolved.