### PR TITLE
Multiple Signatures for the same Mime Type

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/modules/filetypeid/FileTypeIdGlobalSettingsPanel.java
+++ b/Core/src/org/sleuthkit/autopsy/modules/filetypeid/FileTypeIdGlobalSettingsPanel.java
@@ -34,7 +34,6 @@ import javax.swing.event.DocumentListener;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 import javax.xml.bind.DatatypeConverter;
-import org.openide.util.Exceptions;
 import org.openide.util.NbBundle;
 import org.sleuthkit.autopsy.corecomponents.OptionsPanel;
 import org.sleuthkit.autopsy.ingest.IngestManager;
@@ -640,7 +639,11 @@ final class FileTypeIdGlobalSettingsPanel extends IngestModuleGlobalSettingsPane
          */
         FileType.Signature signature = new FileType.Signature(signatureBytes, offset, sigType);
         FileType fileType = new FileType(typeName, signature, filesSetName, postHitCheckBox.isSelected());
-        fileTypes.put(typeName, fileType);
+
+        // remove the existing and add the new modified one.
+        fileTypes.remove(typesList.getSelectedValue());
+        fileTypes.put(typeName + " - " + DatatypeConverter.printHexBinary(signatureBytes) + " - " + Long.toString(offset), fileType);
+
         updateFileTypesListModel();
         typesList.setSelectedValue(fileType.getMimeType(), true);
     }//GEN-LAST:event_saveTypeButtonActionPerformed

--- a/Core/src/org/sleuthkit/autopsy/modules/filetypeid/UserDefinedFileTypesManager.java
+++ b/Core/src/org/sleuthkit/autopsy/modules/filetypeid/UserDefinedFileTypesManager.java
@@ -36,7 +36,6 @@ import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 import javax.xml.bind.DatatypeConverter;
 import javax.xml.transform.TransformerException;
-import org.apache.commons.lang.ArrayUtils;
 import org.openide.util.NbBundle;
 import org.sleuthkit.autopsy.coreutils.Logger;
 import org.sleuthkit.autopsy.coreutils.PlatformUtil;

--- a/Core/src/org/sleuthkit/autopsy/modules/filetypeid/UserDefinedFileTypesManager.java
+++ b/Core/src/org/sleuthkit/autopsy/modules/filetypeid/UserDefinedFileTypesManager.java
@@ -36,6 +36,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 import javax.xml.bind.DatatypeConverter;
 import javax.xml.transform.TransformerException;
+import org.apache.commons.lang.ArrayUtils;
 import org.openide.util.NbBundle;
 import org.sleuthkit.autopsy.coreutils.Logger;
 import org.sleuthkit.autopsy.coreutils.PlatformUtil;
@@ -182,7 +183,7 @@ final class UserDefinedFileTypesManager {
     private void loadPredefinedFileTypes() throws UserDefinedFileTypesException {
         try {
             FileType fileType = new FileType("text/xml", new Signature("<?xml".getBytes(ASCII_ENCODING), 0L, FileType.Signature.Type.ASCII), "", false); //NON-NLS
-            fileTypes.put(fileType.getMimeType(), fileType);
+            fileTypes.put(fileType.getMimeType() + " - " + DatatypeConverter.printHexBinary(fileType.getSignature().getSignatureBytes()) + " - " + Long.toString(fileType.getSignature().getOffset()), fileType); // NON-NLS
 
         } catch (UnsupportedEncodingException ex) {
             /**
@@ -227,8 +228,8 @@ final class UserDefinedFileTypesManager {
      * @param fileType The file type to add.
      */
     private void addUserDefinedFileType(FileType fileType) {
-        userDefinedFileTypes.put(fileType.getMimeType(), fileType);
-        fileTypes.put(fileType.getMimeType(), fileType);
+        userDefinedFileTypes.put(fileType.getMimeType() + " - " + DatatypeConverter.printHexBinary(fileType.getSignature().getSignatureBytes()) + " - " + Long.toString(fileType.getSignature().getOffset()), fileType); // NON-NLS
+        fileTypes.put(fileType.getMimeType() + " - " + DatatypeConverter.printHexBinary(fileType.getSignature().getSignatureBytes()) + " - " + Long.toString(fileType.getSignature().getOffset()), fileType); // NON-NLS
     }
 
     /**


### PR DESCRIPTION
Same MimeType can have multiple signature/offset combination.
1. Map<String, FileType> fileTypes's key changed from "TypeName" to "TypeName + Signature + Offset"