### PR TITLE
Python settings persistence

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/ingest/IngestJobSettings.java
+++ b/Core/src/org/sleuthkit/autopsy/ingest/IngestJobSettings.java
@@ -54,7 +54,7 @@ public class IngestJobSettings {
     private static final Logger logger = Logger.getLogger(IngestJobSettings.class.getName());
     private final String context;
     private String moduleSettingsFolderPath;
-    private static final CharSequence pythonModuleSettingsPrefixCS = "org.python.proxies.".subSequence(0, "org.python.proxies.".length() - 1);
+    private static final CharSequence pythonModulePrefixCS = "org.python.proxies.".subSequence(0, "org.python.proxies.".length() - 1);
     private final List<IngestModuleTemplate> moduleTemplates;
     private boolean processUnallocatedSpace;
     private final List<String> warnings;
@@ -292,7 +292,7 @@ public class IngestJobSettings {
      * @return True or false
      */
     private boolean isPythonModuleSettingsFile(String moduleSettingsFilePath) {
-        return moduleSettingsFilePath.contains(pythonModuleSettingsPrefixCS);
+        return moduleSettingsFilePath.contains(pythonModulePrefixCS);
     }
 
     /**
@@ -341,7 +341,11 @@ public class IngestJobSettings {
      * @return The file path.
      */
     private String getModuleSettingsFilePath(IngestModuleFactory factory) {
-        String fileName = factory.getClass().getCanonicalName() + IngestJobSettings.MODULE_SETTINGS_FILE_EXT;
+        String className = factory.getClass().getCanonicalName();
+        if (className.contains(pythonModulePrefixCS)) {
+            className = className.replaceAll("\\$[\\d]$", "\\$");
+        }
+        String fileName = className + IngestJobSettings.MODULE_SETTINGS_FILE_EXT;
         Path path = Paths.get(this.moduleSettingsFolderPath, fileName);
         return path.toAbsolutePath().toString();
     }

--- a/Core/src/org/sleuthkit/autopsy/python/Bundle.properties
+++ b/Core/src/org/sleuthkit/autopsy/python/Bundle.properties
@@ -1,2 +1,4 @@
 JythonModuleLoader.errorMessages.failedToOpenModule=Failed to open {0}. See log for details.
 JythonModuleLoader.errorMessages.failedToLoadModule=Failed to load {0}.  {1}.  See log for details.
+JythonModuleLoader.createObjectFromScript.reloadScript.title=Python Module reloaded.
+JythonModuleLoader.createObjectFromScript.reloadScript.msg=Python module {0} has changed since the previous ingest operation. This module is reloaded.

--- a/docs/doxygen/modDevPython.dox
+++ b/docs/doxygen/modDevPython.dox
@@ -62,6 +62,7 @@ This section lists some helpful tips that we have found.  These are all now in t
 - We haven't found a good way to debug while running inside of Autopsy.  So, logging becomes critical. You need to go through a bunch of steps to get the logger to display your module name.  See the sample module for a log() method that does all of this for you.
 - When you name the file with your Python module in it, restrict its name to letters, numbers, and underscore (_).
 - Python modules using external libraries which load native code (SciPy, NumPy, etc.) are currently NOT supported. RuntimeError will be thrown.
+- Settings previously serialized to the disk will not persist if any changes are made to the Python module since then; default settings will be loaded.
 
 \section mod_dev_py_distribute Distribution
 To distribute and share your Python module, ZIP up the folder and send it around.  Other users of the module should expand the ZIP file and drop the folder into their Autopsy Python folder. 


### PR DESCRIPTION
1. Reload py module only if python module content is modified (eg new files added/ existing file content modified) since the last usage (IngestModuleFactoryLoader.getIngestModuleFactories()).
2. Maintain a list of modules and their last usage timing; serialized to the disk.
NOTE: Deletion of files from the module folder will not cause reload.