### PR TITLE
Error observer api devel

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/casemodule/Case.java
+++ b/Core/src/org/sleuthkit/autopsy/casemodule/Case.java
@@ -253,13 +253,12 @@ public class Case implements SleuthkitCase.ErrorObserver {
     private final XMLCaseManagement xmlcm;
     private final SleuthkitCase db;
     // Track the current case (only set with changeCase() method)
-    volatile private static Case currentCase = null;
+    private static Case currentCase = null;
     private final CaseType caseType;
     private final Services services;
     private static final Logger logger = Logger.getLogger(Case.class.getName());
     static final String CASE_EXTENSION = "aut"; //NON-NLS
     static final String CASE_DOT_EXTENSION = "." + CASE_EXTENSION;
-    private static String HostName;
     private final static String CACHE_FOLDER = "Cache"; //NON-NLS
     private final static String EXPORT_FOLDER = "Export"; //NON-NLS
     private final static String LOG_FOLDER = "Log"; //NON-NLS
@@ -374,12 +373,12 @@ public class Case implements SleuthkitCase.ErrorObserver {
     
     @Override
     public void receiveError(String context, String errorMessage) {
-        /* NOTE: We are accessing currentCase.tskErrorReporter from two different threads.
-         * This is ok as long as we only read the value of currentCase.tskErrorReporter
-         * because both currentCase and tskErrorReporter are declared as volatile.
+        /* NOTE: We are accessing tskErrorReporter from two different threads.
+         * This is ok as long as we only read the value of tskErrorReporter
+         * because tskErrorReporter is declared as volatile.
          */
-        if (null != currentCase && null != currentCase.tskErrorReporter) {
-            currentCase.tskErrorReporter.addProblems(context, errorMessage);
+        if (null != tskErrorReporter) {
+            tskErrorReporter.addProblems(context, errorMessage);
         }
     }
 

--- a/Core/src/org/sleuthkit/autopsy/casemodule/Case.java
+++ b/Core/src/org/sleuthkit/autopsy/casemodule/Case.java
@@ -253,7 +253,7 @@ public class Case implements SleuthkitCase.ErrorObserver {
     private final XMLCaseManagement xmlcm;
     private final SleuthkitCase db;
     // Track the current case (only set with changeCase() method)
-    private static Case currentCase = null;
+    volatile private static Case currentCase = null;
     private final CaseType caseType;
     private final Services services;
     private static final Logger logger = Logger.getLogger(Case.class.getName());
@@ -376,9 +376,9 @@ public class Case implements SleuthkitCase.ErrorObserver {
     public void receiveError(String context, String errorMessage) {
         /* NOTE: We are accessing currentCase.tskErrorReporter from two different threads.
          * This is ok as long as we only read the value of currentCase.tskErrorReporter
-         * because currentCase.tskErrorReporter is declared as volatile.
+         * because both currentCase and tskErrorReporter are declared as volatile.
          */
-        if (null != currentCase.tskErrorReporter) {
+        if (null != currentCase && null != currentCase.tskErrorReporter) {
             currentCase.tskErrorReporter.addProblems(context, errorMessage);
         }
     }

--- a/Core/src/org/sleuthkit/autopsy/casemodule/IntervalErrorReportData.java
+++ b/Core/src/org/sleuthkit/autopsy/casemodule/IntervalErrorReportData.java
@@ -77,17 +77,18 @@ class IntervalErrorReportData implements SleuthkitCase.ErrorObserver {
      * (or if this is the first problem encountered), a warning will be shown to
      * the user.
      *
-     * @param newProblems the newProblems to set
-     * @param ex          the exception for this error
+     * @param newProblems  the newProblems to set
+     * @param context      The context in which the error occurred.
+     * @param errorMessage A description of the error that occurred.
      */
-    private void addProblems(long newProblems, Exception ex) {
+    private void addProblems(long newProblems, String context, String errorMessage) {
         this.newProblems += newProblems;
         this.totalProblems += newProblems;
 
         long currentTimeStamp = System.currentTimeMillis();
         if ((currentTimeStamp - lastReportedDate) > milliSecondsBetweenReports) {
             this.lastReportedDate = currentTimeStamp;
-            MessageNotifyUtil.Notify.error(message, ex.getMessage() + " "
+            MessageNotifyUtil.Notify.error(message, context + ", " + errorMessage + " "
                     + this.newProblems + " "
                     + NbBundle.getMessage(IntervalErrorReportData.class, "IntervalErrorReport.NewIssues")
                     + " " + this.totalProblems + " "
@@ -98,7 +99,7 @@ class IntervalErrorReportData implements SleuthkitCase.ErrorObserver {
     }
 
     @Override
-    public void receiveError(Exception ex) {
-        addProblems(1, ex);
+    public void receiveError(String context, String errorMessage) {
+        addProblems(1, context, errorMessage);
     }
 }

--- a/Core/src/org/sleuthkit/autopsy/casemodule/IntervalErrorReportData.java
+++ b/Core/src/org/sleuthkit/autopsy/casemodule/IntervalErrorReportData.java
@@ -20,16 +20,15 @@ package org.sleuthkit.autopsy.casemodule;
 
 import org.openide.util.NbBundle;
 import org.sleuthkit.autopsy.coreutils.MessageNotifyUtil;
-import org.sleuthkit.datamodel.SleuthkitCase;
 
 /**
  * This class enables capturing errors and batching them for reporting on a
- * no-more-than-x number of seconds basis. When created, you specify what type
- * of error it will be batching, and the minimum time between user
- * notifications. When the time between notifications has expired, the next
- * error encountered will cause a report to be shown to the user.
+ * no-more-than-x number of seconds basis. When created, you specify the minimum
+ * time between user notifications. When the time between notifications has
+ * expired, the next error encountered will cause a report to be shown to the
+ * user.
  */
-class IntervalErrorReportData implements SleuthkitCase.ErrorObserver {
+class IntervalErrorReportData {
 
     private final Case currentCase;
     private long newProblems;
@@ -39,7 +38,8 @@ class IntervalErrorReportData implements SleuthkitCase.ErrorObserver {
     private final String message;
 
     /**
-     * Create a new IntervalErrorReprotData instance.
+     * Create a new IntervalErrorReprotData instance and subscribe for TSK error
+     * notifications for the current case.
      *
      * @param currentCase           Case for which TSK errors should be tracked
      *                              and displayed.
@@ -48,21 +48,21 @@ class IntervalErrorReportData implements SleuthkitCase.ErrorObserver {
      * @param message               The message that will be shown when warning
      *                              the user
      */
-    public IntervalErrorReportData(Case currentCase, int secondsBetweenReports, String message) {
+    IntervalErrorReportData(Case currentCase, int secondsBetweenReports, String message) {
         this.newProblems = 0;
         this.totalProblems = 0;
         this.lastReportedDate = 0; // arm the first warning by choosing zero
         this.milliSecondsBetweenReports = secondsBetweenReports * 1000;  // convert to milliseconds
         this.message = message;
         this.currentCase = currentCase;
-        this.currentCase.getSleuthkitCase().addErrorObserver(this); // it's ok to use "this" at the end of the constructor
+        this.currentCase.getSleuthkitCase().addErrorObserver(this.currentCase);
     }
     
     /**
-     * Shuts down this IntervalErrorReprotData instance.
+     * Un-subscribe from TSK error notifications for current case.
      */
-    public void shutdown() {
-        this.currentCase.getSleuthkitCase().removeErrorObserver(this);
+    void shutdown() {
+        this.currentCase.getSleuthkitCase().removeErrorObserver(this.currentCase);
     }
 
     /**
@@ -70,12 +70,11 @@ class IntervalErrorReportData implements SleuthkitCase.ErrorObserver {
      * (or if this is the first problem encountered), a warning will be shown to
      * the user.
      *
-     * @param newProblems  the newProblems to set
      * @param context      The context in which the error occurred.
      * @param errorMessage A description of the error that occurred.
      */
-    private void addProblems(long newProblems, String context, String errorMessage) {
-        this.newProblems += newProblems;
+    void addProblems(String context, String errorMessage) {
+        this.newProblems += 1;
         this.totalProblems += newProblems;
 
         long currentTimeStamp = System.currentTimeMillis();
@@ -89,10 +88,5 @@ class IntervalErrorReportData implements SleuthkitCase.ErrorObserver {
                     + ".");
             this.newProblems = 0;
         }
-    }
-
-    @Override
-    public void receiveError(String context, String errorMessage) {
-        addProblems(1, context, errorMessage);
     }
 }


### PR DESCRIPTION
- Modified Case class to be TSK error subscriber again
- Modified Case class to use non-static SleuthkitCase ErrorObserver API 
- Made IntervalErrorReportObserver no longer be a singleton
- Modified Case class create and destroy instances of IntervalErrorReportObserver in changeCase(), analogous to the way new CollaborationMonitors are made for each case