### PR TITLE
Add ingest cancellation reasons

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/casemodule/Case.java
+++ b/Core/src/org/sleuthkit/autopsy/casemodule/Case.java
@@ -73,6 +73,7 @@ import org.sleuthkit.autopsy.casemodule.events.ContentTagAddedEvent;
 import org.sleuthkit.autopsy.casemodule.events.ContentTagDeletedEvent;
 import org.sleuthkit.autopsy.core.RuntimeProperties;
 import org.sleuthkit.autopsy.core.UserPreferencesException;
+import org.sleuthkit.autopsy.ingest.IngestJob;
 import org.sleuthkit.autopsy.ingest.IngestManager;
 import org.sleuthkit.datamodel.BlackboardArtifactTag;
 import org.sleuthkit.datamodel.Content;
@@ -327,7 +328,7 @@ public class Case implements SleuthkitCase.ErrorObserver {
             SwingUtilities.invokeLater(() -> {
                 WindowManager.getDefault().getMainWindow().setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
             });
-            IngestManager.getInstance().cancelAllIngestJobs();
+            IngestManager.getInstance().cancelAllIngestJobs(IngestJob.CancellationReason.CASE_CLOSED);
             doCaseChange(null); //closes windows, etc   
             if (null != oldCase.tskErrorReporter) {
                 oldCase.tskErrorReporter.shutdown(); // stop listening for TSK errors for the old case

--- a/Core/src/org/sleuthkit/autopsy/ingest/IngestManager.java
+++ b/Core/src/org/sleuthkit/autopsy/ingest/IngestManager.java
@@ -357,7 +357,7 @@ public class IngestManager {
                     }
 
                     // cancel ingest if running
-                    cancelAllIngestJobs();
+                    cancelAllIngestJobs(IngestJob.CancellationReason.SERVICES_DOWN);
                 }
             }
         };
@@ -627,8 +627,21 @@ public class IngestManager {
 
     /**
      * Cancels all ingest jobs in progress.
+     *
+     * @deprecated Use cancelAllIngestJobs(IngestJob.CancellationReason reason)
+     * instead.
      */
+    @Deprecated
     public synchronized void cancelAllIngestJobs() {
+        cancelAllIngestJobs(IngestJob.CancellationReason.USER_CANCELLED);
+    }
+
+    /**
+     * Cancels all ingest jobs in progress.
+     *
+     * @param reason The cancellation reason.
+     */
+    public synchronized void cancelAllIngestJobs(IngestJob.CancellationReason reason) {
         // Stop creating new ingest jobs.
         for (Future<Void> handle : ingestJobStarters.values()) {
             handle.cancel(true);
@@ -636,7 +649,7 @@ public class IngestManager {
 
         // Cancel all the jobs already created. 
         for (IngestJob job : this.jobsById.values()) {
-            job.cancel();
+            job.cancel(reason);
         }
     }
 

--- a/Core/src/org/sleuthkit/autopsy/ingest/IngestMonitor.java
+++ b/Core/src/org/sleuthkit/autopsy/ingest/IngestMonitor.java
@@ -196,7 +196,7 @@ public final class IngestMonitor {
                 /*
                  * Shut down ingest by cancelling all ingest jobs.
                  */
-                manager.cancelAllIngestJobs();
+                manager.cancelAllIngestJobs(IngestJob.CancellationReason.OUT_OF_DISK_SPACE);
                 String diskPath = root.getAbsolutePath();
                 IngestServices.getInstance().postMessage(IngestMessage.createManagerErrorMessage(
                         NbBundle.getMessage(this.getClass(), "IngestMonitor.mgrErrMsg.lowDiskSpace.title", diskPath),


### PR DESCRIPTION
- Add cancellation reasons to ingest jobs and their constituent data source ingest jobs (and to snapshots)
- Fix bug in IngestJob.start
- Make DataSourceIngestJob cancellation reflect whether or not job was completed, i.e., no cancellation for individual job if it was not still running
- Formatting