### PR TITLE
Negative array size exception

### DIFF
--- a/branding/core/core.jar/org/netbeans/core/startup/Bundle.properties
+++ b/branding/core/core.jar/org/netbeans/core/startup/Bundle.properties
@@ -1,5 +1,5 @@
 #Updated by build script
-#Mon, 21 Dec 2015 06:26:49 -0500
+#Tue, 19 Jan 2016 12:12:04 +0100
 LBL_splash_window_title=Starting Autopsy
 SPLASH_HEIGHT=314
 SPLASH_WIDTH=538

--- a/branding/modules/org-netbeans-core-windows.jar/org/netbeans/core/windows/view/ui/Bundle.properties
+++ b/branding/modules/org-netbeans-core-windows.jar/org/netbeans/core/windows/view/ui/Bundle.properties
@@ -1,4 +1,4 @@
 #Updated by build script
-#Mon, 21 Dec 2015 06:26:49 -0500
+#Tue, 19 Jan 2016 12:12:04 +0100
 CTL_MainWindow_Title=Autopsy 4.0.0
 CTL_MainWindow_Title_No_Project=Autopsy 4.0.0

--- a/thunderbirdparser/src/org/sleuthkit/autopsy/thunderbirdparser/PstParser.java
+++ b/thunderbirdparser/src/org/sleuthkit/autopsy/thunderbirdparser/PstParser.java
@@ -265,10 +265,14 @@ class PstParser {
                 out.write(buffer);
                 count = attachmentStream.read(buffer);
             }
-
-            byte[] endBuffer = new byte[count];
-            System.arraycopy(buffer, 0, endBuffer, 0, count);
-            out.write(endBuffer);
+            
+            if(count != -1)
+            {
+                //the file size is NOT a multiple of bufferSize
+                byte[] endBuffer = new byte[count];
+                System.arraycopy(buffer, 0, endBuffer, 0, count);
+                out.write(endBuffer);
+            }
         }
     }
 


### PR DESCRIPTION
Same problem as pr #1556 (some other pr reintroduced the exception?)
Slight different patch

This excepion is raised when the attachment size is a multiple of 8176
(the buffer size).

InputStream read methos return -1 if there is no more data because the
end of the stream has been reached

A simple check if result != -1 is added

refs:
http://forum.sleuthkit.org/viewtopic.php?f=6&t=2563
http://docs.oracle.com/javase/7/docs/api/java/io/InputStream.html#read()