### PR TITLE
Temp excise of persistent column ordering

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/corecomponents/DataResultViewerTable.java
+++ b/Core/src/org/sleuthkit/autopsy/corecomponents/DataResultViewerTable.java
@@ -30,15 +30,10 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.logging.Level;
 import javax.swing.Action;
 import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
 import javax.swing.SwingUtilities;
-import javax.swing.event.ChangeEvent;
-import javax.swing.event.ListSelectionEvent;
-import javax.swing.event.TableColumnModelEvent;
-import javax.swing.event.TableColumnModelListener;
 import org.netbeans.swing.outline.DefaultOutlineModel;
 import org.openide.explorer.ExplorerManager;
 import org.openide.explorer.view.OutlineView;
@@ -53,10 +48,7 @@ import org.openide.nodes.NodeMemberEvent;
 import org.openide.nodes.NodeReorderEvent;
 import org.openide.nodes.Sheet;
 import org.openide.util.NbBundle;
-import org.openide.util.NbPreferences;
-import org.sleuthkit.autopsy.casemodule.Case;
 import org.sleuthkit.autopsy.corecomponentinterfaces.DataResultViewer;
-import org.sleuthkit.autopsy.coreutils.Logger;
 
 /**
  * DataResult sortable table viewer
@@ -101,52 +93,66 @@ public class DataResultViewerTable extends AbstractDataResultViewer {
         // don't show the root node
         ov.getOutline().setRootVisible(false);
         ov.getOutline().setDragEnabled(false);
-        
-        ov.getOutline().getColumnModel().addColumnModelListener(new TableColumnModelListener() {
-            @Override
-            public void columnAdded(TableColumnModelEvent e) {}
-            @Override
-            public void columnRemoved(TableColumnModelEvent e) {}
-            @Override
-            public void columnMarginChanged(ChangeEvent e) {}
-            @Override
-            public void columnSelectionChanged(ListSelectionEvent e) {}
 
-            @Override
-            public void columnMoved(TableColumnModelEvent e) {
-                // change the order of the column in the array/hashset
-                List<Node.Property<?>> props = new ArrayList<>(propertiesAcc);
-                Node.Property<?> prop = props.remove(e.getFromIndex());
-                props.add(e.getToIndex(), prop);
-                
-                propertiesAcc.clear();
-                for (int j = 0; j < props.size(); ++j) {
-                    propertiesAcc.add(props.get(j));
-                }
-            }
-        });
+        /*
+         * TODO (AUT-1849): Correct or remove peristent column reordering code
+         *
+         * The following lines of code were added for this feature.
+         */
+//        ov.getOutline().getColumnModel().addColumnModelListener(new TableColumnModelListener() {
+//            @Override
+//            public void columnAdded(TableColumnModelEvent e) {}
+//            @Override
+//            public void columnRemoved(TableColumnModelEvent e) {}
+//            @Override
+//            public void columnMarginChanged(ChangeEvent e) {}
+//            @Override
+//            public void columnSelectionChanged(ListSelectionEvent e) {}
+//
+//            @Override
+//            public void columnMoved(TableColumnModelEvent e) {
+//                // change the order of the column in the array/hashset
+//                List<Node.Property<?>> props = new ArrayList<>(propertiesAcc);
+//                Node.Property<?> prop = props.remove(e.getFromIndex());
+//                props.add(e.getToIndex(), prop);
+//                
+//                propertiesAcc.clear();
+//                for (int j = 0; j < props.size(); ++j) {
+//                    propertiesAcc.add(props.get(j));
+//                }
+//            }
+//        });
         /**
-         * Add mouse listener to perform action on double-click
-         * A somewhat hacky way to perform action even if the column clicked 
-         * is not the first one.
+         * Add mouse listener to perform action on double-click A somewhat hacky
+         * way to perform action even if the column clicked is not the first
+         * one.
          */
         ov.getOutline().addMouseListener(new MouseListener() {
             @Override
-            public void mousePressed(MouseEvent e) {}
+            public void mousePressed(MouseEvent e) {
+            }
+
             @Override
-            public void mouseReleased(MouseEvent e) {}
+            public void mouseReleased(MouseEvent e) {
+            }
+
             @Override
-            public void mouseEntered(MouseEvent e) {}
+            public void mouseEntered(MouseEvent e) {
+            }
+
             @Override
-            public void mouseExited(MouseEvent e) {}
+            public void mouseExited(MouseEvent e) {
+            }
+
             @Override
             public void mouseClicked(MouseEvent e) {
-                if(e.getClickCount() == 2) {
+                if (e.getClickCount() == 2) {
                     Node[] nodes = DataResultViewerTable.this.em.getSelectedNodes();
-                    for(Node node : nodes) {
+                    for (Node node : nodes) {
                         Action action = node.getPreferredAction();
-                        if(action != null) 
+                        if (action != null) {
                             action.actionPerformed(null);
+                        }
                     }
                 }
             }
@@ -354,12 +360,20 @@ public class DataResultViewerTable extends AbstractDataResultViewer {
         if (ov == null) {
             return;
         }
-        
-        storeState();
-        
+
+        /*
+         * TODO (AUT-1849): Correct or remove peristent column reordering code
+         *
+         * The next three lines of code replaced the three lines of code that
+         * follow
+         */
+//        storeState();        
         // set the new root as current
-        currentRoot = root;
-        List<Node.Property<?>> props = loadState();
+//        currentRoot = root;
+//        List<Node.Property<?>> props = loadState();
+        propertiesAcc.clear();
+        DataResultViewerTable.this.getAllChildPropertyHeadersRec(root, 100);
+        List<Node.Property<?>> props = new ArrayList<>(propertiesAcc);
 
         /*
          * OutlineView makes the first column be the result of
@@ -423,7 +437,7 @@ public class DataResultViewerTable extends AbstractDataResultViewer {
                     ov.getOutline().getColumnModel().getColumn(colIndex).setPreferredWidth(colWidth);
                 }
             }
-            
+
             // if there's no content just auto resize all columns
             if (content.length <= 0) {
                 // turn on the auto resize
@@ -431,65 +445,70 @@ public class DataResultViewerTable extends AbstractDataResultViewer {
             }
         }
     }
-    
+
+    /*
+     * TODO (AUT-1849): Correct or remove peristent column reordering code
+     * 
+     * The following three methods were added for this feature
+     */
     // Store the state of current root Node.
-    private void storeState() {
-        if(currentRoot == null || propertiesAcc.isEmpty())
-            return;
-        
-        TableFilterNode tfn;
-        if(currentRoot instanceof TableFilterNode)
-            tfn = (TableFilterNode) currentRoot;
-        else
-            return;
-        
-        List<Node.Property<?>> props = new ArrayList<>(propertiesAcc);
-        for (int i = 0; i < props.size(); i++) {
-            Property<?> prop = props.get(i);
-            NbPreferences.forModule(this.getClass()).put(getUniqueColName(prop, tfn.getItemType()), String.valueOf(i));
-        }
-    }
-    
+//    private void storeState() {
+//        if(currentRoot == null || propertiesAcc.isEmpty())
+//            return;
+//        
+//        TableFilterNode tfn;
+//        if(currentRoot instanceof TableFilterNode)
+//            tfn = (TableFilterNode) currentRoot;
+//        else
+//            return;
+//        
+//        List<Node.Property<?>> props = new ArrayList<>(propertiesAcc);
+//        for (int i = 0; i < props.size(); i++) {
+//            Property<?> prop = props.get(i);
+//            NbPreferences.forModule(this.getClass()).put(getUniqueColName(prop, tfn.getItemType()), String.valueOf(i));
+//        }
+//    }
     // Load the state of current root Node if exists. 
-    private List<Node.Property<?>> loadState() {
-        propertiesAcc.clear();
-        this.getAllChildPropertyHeadersRec(currentRoot, 100);
-        List<Node.Property<?>> props = new ArrayList<>(propertiesAcc);
-        
-        // If node is not table filter node, use default order for columns
-        TableFilterNode tfn;
-        if(currentRoot instanceof TableFilterNode) {
-            tfn = (TableFilterNode) currentRoot;
-        }
-        else {
-            Logger.getLogger(DataResultViewerTable.class.getName()).log(Level.INFO, 
-                    "Node {0} is not TableFilterNode, columns are going to be in default order", currentRoot.getName());
-            return props;
-        }
-        
-        List<Node.Property<?>> orderedProps = new ArrayList<>(propertiesAcc);
-        for (Property<?> prop : props) {
-            Integer value = Integer.valueOf(NbPreferences.forModule(this.getClass()).get(getUniqueColName(prop, tfn.getItemType()), "-1"));
-            if (value >= 0) {
-                /**
-                 * The original contents of orderedProps do not matter when setting the new ordered values. The reason
-                 * we copy propertiesAcc into it first is to give it the currect size so we can set() in any index.
-                 */
-                orderedProps.set(value, prop);
-            }
-        }
-        propertiesAcc.clear();
-        for (Property<?> prop : orderedProps) {
-            propertiesAcc.add(prop);
-        }
-        return orderedProps;
-    }
-    
-    // Get unique name for node and it's property.
-    private String getUniqueColName(Property<?> prop, String type) {
-        return Case.getCurrentCase().getName() + "." + type + "." 
-                + prop.getName().replaceAll("[^a-zA-Z0-9_]", "") + ".columnOrder";
-    }
+//    private List<Node.Property<?>> loadState() {
+//        propertiesAcc.clear();
+//        this.getAllChildPropertyHeadersRec(currentRoot, 100);
+//        List<Node.Property<?>> props = new ArrayList<>(propertiesAcc);
+//
+//        // If node is not table filter node, use default order for columns
+//        TableFilterNode tfn;
+//        if (currentRoot instanceof TableFilterNode) {
+//            tfn = (TableFilterNode) currentRoot;
+//        } else {
+//            Logger.getLogger(DataResultViewerTable.class.getName()).log(Level.INFO,
+//                    "Node {0} is not TableFilterNode, columns are going to be in default order", currentRoot.getName());
+//            return props;
+//        }
+//
+//        List<Node.Property<?>> orderedProps = new ArrayList<>(propertiesAcc);
+//        for (Property<?> prop : props) {
+//            Integer value = Integer.valueOf(NbPreferences.forModule(this.getClass()).get(getUniqueColName(prop, tfn.getItemType()), "-1"));
+//            if (value >= 0) {
+//                /**
+//                 * The original contents of orderedProps do not matter when
+//                 * setting the new ordered values. The reason we copy
+//                 * propertiesAcc into it first is to give it the currect size so
+//                 * we can set() in any index.
+//                 */
+//                orderedProps.set(value, prop);
+//            }
+//        }
+//        propertiesAcc.clear();
+//        for (Property<?> prop : orderedProps) {
+//            propertiesAcc.add(prop);
+//        }
+//        return orderedProps;
+//    }
+//
+//    // Get unique name for node and it's property.
+//    private String getUniqueColName(Property<?> prop, String type) {
+//        return Case.getCurrentCase().getName() + "." + type + "."
+//                + prop.getName().replaceAll("[^a-zA-Z0-9_]", "") + ".columnOrder";
+//    }
 
     // Populate a two-dimensional array with rows of property values for up 
     // to maxRows children of the node passed in. 

--- a/Core/src/org/sleuthkit/autopsy/datamodel/BlackboardArtifactNode.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/BlackboardArtifactNode.java
@@ -414,8 +414,13 @@ public class BlackboardArtifactNode extends DisplayableItemNode {
         return true;
     }
 
-    @Override
-    public String getItemType() {
-        return "BlackboardArtifact"; //NON-NLS
-    }
+    /*
+     * TODO (AUT-1849): Correct or remove peristent column reordering code
+     *
+     * Added to support this feature.
+     */
+//    @Override
+//    public String getItemType() {
+//        return "BlackboardArtifact"; //NON-NLS
+//    }
 }

--- a/Core/src/org/sleuthkit/autopsy/datamodel/BlackboardArtifactTagNode.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/BlackboardArtifactTagNode.java
@@ -108,8 +108,13 @@ public class BlackboardArtifactTagNode extends DisplayableItemNode {
         return true;
     }
 
-    @Override
-    public String getItemType() {
-        return "BlackboardArtifactTag"; //NON-NLS
-    }
+    /*
+     * TODO (AUT-1849): Correct or remove peristent column reordering code
+     *
+     * Added to support this feature.
+     */
+//    @Override
+//    public String getItemType() {
+//        return "BlackboardArtifactTag"; //NON-NLS
+//    }
 }

--- a/Core/src/org/sleuthkit/autopsy/datamodel/ContentTagNode.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/ContentTagNode.java
@@ -122,8 +122,13 @@ class ContentTagNode extends DisplayableItemNode {
         return true;
     }
 
-    @Override
-    public String getItemType() {
-        return "ContentTag"; //NON-NLS
-    }
+    /*
+     * TODO (AUT-1849): Correct or remove peristent column reordering code
+     *
+     * Added to support this feature.
+     */
+//    @Override
+//    public String getItemType() {
+//        return "ContentTag"; //NON-NLS
+//    }
 }

--- a/Core/src/org/sleuthkit/autopsy/datamodel/DataSourcesNode.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/DataSourcesNode.java
@@ -56,10 +56,15 @@ public class DataSourcesNode extends DisplayableItemNode {
         this.setIconBaseWithExtension("org/sleuthkit/autopsy/images/image.png"); //NON-NLS
     }
 
-    @Override
-    public String getItemType() {
-        return "DataSources"; //NON-NLS
-    }
+    /*
+     * TODO (AUT-1849): Correct or remove peristent column reordering code
+     *
+     * Added to support this feature.
+     */
+//    @Override
+//    public String getItemType() {
+//        return "DataSources"; //NON-NLS
+//    }
 
     /*
      * Custom Keys implementation that listens for new data sources being added.

--- a/Core/src/org/sleuthkit/autopsy/datamodel/DeletedContent.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/DeletedContent.java
@@ -147,10 +147,15 @@ public class DeletedContent implements AutopsyVisitableItem {
             return s;
         }
 
-        @Override
-        public String getItemType() {
-            return "DeletedContent"; //NON-NLS
-        }
+        /*
+         * TODO (AUT-1849): Correct or remove peristent column reordering code
+         *
+         * Added to support this feature.
+         */
+//        @Override
+//        public String getItemType() {
+//            return "DeletedContent"; //NON-NLS
+//        }
     }
 
     public static class DeletedContentsChildren extends ChildFactory<DeletedContent.DeletedContentFilter> {
@@ -280,11 +285,16 @@ public class DeletedContent implements AutopsyVisitableItem {
                 updateDisplayName();
             }
 
-            @Override
-            public String getItemType() {
-                return "DeletedContentChildren"; //NON-NLS
-            }
-
+            /*
+             * TODO (AUT-1849): Correct or remove peristent column reordering
+             * code
+             *
+             * Added to support this feature.
+             */
+//            @Override
+//            public String getItemType() {
+//                return "DeletedContentChildren"; //NON-NLS
+//            }
             // update the display name when new events are fired
             private class DeletedContentNodeObserver implements Observer {
 
@@ -347,7 +357,6 @@ public class DeletedContent implements AutopsyVisitableItem {
             private final Observer observer = new DeletedContentChildrenObserver();
 
             // Cause refresh of children if there are changes
-
             private class DeletedContentChildrenObserver implements Observer {
 
                 @Override

--- a/Core/src/org/sleuthkit/autopsy/datamodel/DirectoryNode.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/DirectoryNode.java
@@ -101,8 +101,13 @@ public class DirectoryNode extends AbstractFsContentNode<AbstractFile> {
         return false;
     }
 
-    @Override
-    public String getItemType() {
-        return "Directory"; //NON-NLS
-    }
+    /*
+     * TODO (AUT-1849): Correct or remove peristent column reordering code
+     *
+     * Added to support this feature.
+     */
+//    @Override
+//    public String getItemType() {
+//        return "Directory"; //NON-NLS
+//    }
 }

--- a/Core/src/org/sleuthkit/autopsy/datamodel/DisplayableItemNode.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/DisplayableItemNode.java
@@ -40,6 +40,11 @@ public abstract class DisplayableItemNode extends AbstractNode {
     public abstract boolean isLeafTypeNode();
 
     public abstract <T> T accept(DisplayableItemNodeVisitor<T> v);
-    
-    public abstract String getItemType();
+
+    /*
+     * TODO (AUT-1849): Correct or remove peristent column reordering code
+     * 
+     * Added to support this feature.
+     */
+//    public abstract String getItemType();
 }

--- a/Core/src/org/sleuthkit/autopsy/datamodel/EmailExtracted.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/EmailExtracted.java
@@ -191,10 +191,15 @@ public class EmailExtracted implements AutopsyVisitableItem {
             return s;
         }
 
-        @Override
-        public String getItemType() {
-            return "EmailExtractedRoot"; //NON-NLS
-        }
+        /*
+         * TODO (AUT-1849): Correct or remove peristent column reordering code
+         *
+         * Added to support this feature.
+         */
+//        @Override
+//        public String getItemType() {
+//            return "EmailExtractedRoot"; //NON-NLS
+//        }
     }
 
     /**
@@ -346,10 +351,15 @@ public class EmailExtracted implements AutopsyVisitableItem {
             updateDisplayName();
         }
 
-        @Override
-        public String getItemType() {
-            return "EmailExtractedAccount"; //NON-NLS
-        }
+        /*
+         * TODO (AUT-1849): Correct or remove peristent column reordering code
+         *
+         * Added to support this feature.
+         */
+//        @Override
+//        public String getItemType() {
+//            return "EmailExtractedAccount"; //NON-NLS
+//        }
     }
 
     /**
@@ -437,10 +447,15 @@ public class EmailExtracted implements AutopsyVisitableItem {
             updateDisplayName();
         }
 
-        @Override
-        public String getItemType() {
-            return "EmailExtractedFolder"; //NON-NLS
-        }
+        /*
+         * TODO (AUT-1849): Correct or remove peristent column reordering code
+         *
+         * Added to support this feature.
+         */
+//        @Override
+//        public String getItemType() {
+//            return "EmailExtractedFolder"; //NON-NLS
+//        }
     }
 
     /**

--- a/Core/src/org/sleuthkit/autopsy/datamodel/ExtractedContent.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/ExtractedContent.java
@@ -183,10 +183,15 @@ public class ExtractedContent implements AutopsyVisitableItem {
             return s;
         }
 
-        @Override
-        public String getItemType() {
-            return "ExtractedContentRoot"; //NON-NLS
-        }
+        /*
+         * TODO (AUT-1849): Correct or remove peristent column reordering code
+         *
+         * Added to support this feature.
+         */
+//        @Override
+//        public String getItemType() {
+//            return "ExtractedContentRoot"; //NON-NLS
+//        }
     }
 
     /**
@@ -400,10 +405,15 @@ public class ExtractedContent implements AutopsyVisitableItem {
             return true;
         }
 
-        @Override
-        public String getItemType() {
-            return type.getDisplayName();
-        }
+        /*
+         * TODO (AUT-1849): Correct or remove peristent column reordering code
+         *
+         * Added to support this feature.
+         */
+//        @Override
+//        public String getItemType() {
+//            return type.getDisplayName();
+//        }
     }
 
     /**

--- a/Core/src/org/sleuthkit/autopsy/datamodel/FileNode.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/FileNode.java
@@ -184,8 +184,13 @@ public class FileNode extends AbstractFsContentNode<AbstractFile> {
         return true;
     }
 
-    @Override
-    public String getItemType() {
-        return "File"; //NON-NLS
-    }
+    /*
+     * TODO (AUT-1849): Correct or remove peristent column reordering code
+     *
+     * Added to support this feature.
+     */
+//    @Override
+//    public String getItemType() {
+//        return "File"; //NON-NLS
+//    }
 }

--- a/Core/src/org/sleuthkit/autopsy/datamodel/FileSize.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/FileSize.java
@@ -144,10 +144,15 @@ public class FileSize implements AutopsyVisitableItem {
             return s;
         }
 
-        @Override
-        public String getItemType() {
-            return "FileSizeRoot"; //NON-NLS
-        }
+        /*
+         * TODO (AUT-1849): Correct or remove peristent column reordering code
+         *
+         * Added to support this feature.
+         */
+//        @Override
+//        public String getItemType() {
+//            return "FileSizeRoot"; //NON-NLS
+//        }
     }
 
     /*
@@ -286,11 +291,16 @@ public class FileSize implements AutopsyVisitableItem {
                 updateDisplayName();
             }
 
-            @Override
-            public String getItemType() {
-                return "FileSize"; //NON-NLS
-            }
-
+            /*
+             * TODO (AUT-1849): Correct or remove peristent column reordering
+             * code
+             *
+             * Added to support this feature.
+             */
+//            @Override
+//            public String getItemType() {
+//                return "FileSize"; //NON-NLS
+//            }
             // update the display name when new events are fired
             private class FileSizeNodeObserver implements Observer {
 

--- a/Core/src/org/sleuthkit/autopsy/datamodel/FileTypeNode.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/FileTypeNode.java
@@ -82,10 +82,15 @@ public class FileTypeNode extends DisplayableItemNode {
         this.setIconBaseWithExtension("org/sleuthkit/autopsy/images/file-filter-icon.png"); //NON-NLS
     }
 
-    @Override
-    public String getItemType() {
-        return "FileType"; //NON-NLS
-    }
+    /*
+     * TODO (AUT-1849): Correct or remove peristent column reordering code
+     *
+     * Added to support this feature.
+     */
+//    @Override
+//    public String getItemType() {
+//        return "FileType"; //NON-NLS
+//    }
 
     // update the display name when new events are fired
     private class FileTypeNodeObserver implements Observer {

--- a/Core/src/org/sleuthkit/autopsy/datamodel/FileTypesNode.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/FileTypesNode.java
@@ -104,16 +104,21 @@ public class FileTypesNode extends DisplayableItemNode {
         return s;
     }
 
-    @Override
-    public String getItemType() {
-        if(filter == null)
-            return "FileTypes"; //NON-NLS
-        if (filter.equals(FileTypeExtensionFilters.RootFilter.TSK_DOCUMENT_FILTER))
-            return "FileTypesDoc"; //NON-NLS
-        if (filter.equals(FileTypeExtensionFilters.RootFilter.TSK_EXECUTABLE_FILTER))
-            return "FileTypesExe"; //NON-NLS
-        return "FileTypes"; //NON-NLS
-    }
+    /*
+     * TODO (AUT-1849): Correct or remove peristent column reordering code
+     *
+     * Added to support this feature.
+     */
+//    @Override
+//    public String getItemType() {
+//        if(filter == null)
+//            return "FileTypes"; //NON-NLS
+//        if (filter.equals(FileTypeExtensionFilters.RootFilter.TSK_DOCUMENT_FILTER))
+//            return "FileTypesDoc"; //NON-NLS
+//        if (filter.equals(FileTypeExtensionFilters.RootFilter.TSK_EXECUTABLE_FILTER))
+//            return "FileTypesExe"; //NON-NLS
+//        return "FileTypes"; //NON-NLS
+//    }
 
     /**
      *

--- a/Core/src/org/sleuthkit/autopsy/datamodel/HashsetHits.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/HashsetHits.java
@@ -169,10 +169,15 @@ public class HashsetHits implements AutopsyVisitableItem {
             return s;
         }
 
-        @Override
-        public String getItemType() {
-            return "HashsetRoot"; //NON-NLS
-        }
+        /*
+         * TODO (AUT-1849): Correct or remove peristent column reordering code
+         *
+         * Added to support this feature.
+         */
+//        @Override
+//        public String getItemType() {
+//            return "HashsetRoot"; //NON-NLS
+//        }
     }
 
     /**
@@ -327,10 +332,15 @@ public class HashsetHits implements AutopsyVisitableItem {
             updateDisplayName();
         }
 
-        @Override
-        public String getItemType() {
-            return "HashsetName"; //NON-NLS
-        }
+        /*
+         * TODO (AUT-1849): Correct or remove peristent column reordering code
+         *
+         * Added to support this feature.
+         */
+//        @Override
+//        public String getItemType() {
+//            return "HashsetName"; //NON-NLS
+//        }
     }
 
     /**

--- a/Core/src/org/sleuthkit/autopsy/datamodel/ImageNode.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/ImageNode.java
@@ -110,8 +110,13 @@ public class ImageNode extends AbstractContentNode<Image> {
         return v.visit(this);
     }
 
-    @Override
-    public String getItemType() {
-        return "Image"; //NON-NLS
-    }
+    /*
+     * TODO (AUT-1849): Correct or remove peristent column reordering code
+     *
+     * Added to support this feature.
+     */
+//    @Override
+//    public String getItemType() {
+//        return "Image"; //NON-NLS
+//    }
 }

--- a/Core/src/org/sleuthkit/autopsy/datamodel/InterestingHits.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/InterestingHits.java
@@ -162,10 +162,15 @@ public class InterestingHits implements AutopsyVisitableItem {
             return s;
         }
 
-        @Override
-        public String getItemType() {
-            return "InterestingHitsRoot"; //NON-NLS
-        }
+        /*
+         * TODO (AUT-1849): Correct or remove peristent column reordering code
+         *
+         * Added to support this feature.
+         */
+//        @Override
+//        public String getItemType() {
+//            return "InterestingHitsRoot"; //NON-NLS
+//        }
     }
 
     private class SetNameFactory extends ChildFactory.Detachable<String> implements Observer {
@@ -313,10 +318,15 @@ public class InterestingHits implements AutopsyVisitableItem {
             updateDisplayName();
         }
 
-        @Override
-        public String getItemType() {
-            return "InterestingHitsSetName"; //NON-NLS
-        }
+        /*
+         * TODO (AUT-1849): Correct or remove peristent column reordering code
+         *
+         * Added to support this feature.
+         */
+//        @Override
+//        public String getItemType() {
+//            return "InterestingHitsSetName"; //NON-NLS
+//        }
     }
 
     private class HitFactory extends ChildFactory<Long> implements Observer {

--- a/Core/src/org/sleuthkit/autopsy/datamodel/KeywordHits.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/KeywordHits.java
@@ -73,7 +73,6 @@ public class KeywordHits implements AutopsyVisitableItem {
     private final class KeywordResults extends Observable {
 
         // Map from listName/Type to Map of keyword to set of artifact Ids
-
         private final Map<String, Map<String, Set<Long>>> topLevelMap;
 
         KeywordResults() {
@@ -240,10 +239,15 @@ public class KeywordHits implements AutopsyVisitableItem {
             return s;
         }
 
-        @Override
-        public String getItemType() {
-            return "KeywordRoot"; //NON-NLS
-        }
+        /*
+         * TODO (AUT-1849): Correct or remove peristent column reordering code
+         *
+         * Added to support this feature.
+         */
+//        @Override
+//        public String getItemType() {
+//            return "KeywordRoot"; //NON-NLS
+//        }
     }
 
     private class ListFactory extends ChildFactory.Detachable<String> implements Observer {
@@ -395,10 +399,15 @@ public class KeywordHits implements AutopsyVisitableItem {
             updateDisplayName();
         }
 
-        @Override
-        public String getItemType() {
-            return "KeywordList"; //NON-NLS
-        }
+        /*
+         * TODO (AUT-1849): Correct or remove peristent column reordering code
+         *
+         * Added to support this feature.
+         */
+//        @Override
+//        public String getItemType() {
+//            return "KeywordList"; //NON-NLS
+//        }
     }
 
     private class TermFactory extends ChildFactory.Detachable<String> implements Observer {
@@ -493,10 +502,15 @@ public class KeywordHits implements AutopsyVisitableItem {
             return s;
         }
 
-        @Override
-        public String getItemType() {
-            return "KeywordTerm"; //NON-NLS
-        }
+        /*
+         * TODO (AUT-1849): Correct or remove peristent column reordering code
+         *
+         * Added to support this feature.
+         */
+//        @Override
+//        public String getItemType() {
+//            return "KeywordTerm"; //NON-NLS
+//        }
     }
 
     public class HitsFactory extends ChildFactory.Detachable<Long> implements Observer {

--- a/Core/src/org/sleuthkit/autopsy/datamodel/LayoutFileNode.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/LayoutFileNode.java
@@ -38,11 +38,15 @@ import org.sleuthkit.datamodel.TskData;
  */
 public class LayoutFileNode extends AbstractAbstractFileNode<LayoutFile> {
 
-    @Override
-    public String getItemType() {
-        return "LayoutFile"; //NON-NLS
-    }
-
+    /*
+     * TODO (AUT-1849): Correct or remove peristent column reordering code
+     *
+     * Added to support this feature.
+     */
+//    @Override
+//    public String getItemType() {
+//        return "LayoutFile"; //NON-NLS
+//    }
     public static enum LayoutContentPropertyType {
 
         PARTS {

--- a/Core/src/org/sleuthkit/autopsy/datamodel/LocalFileNode.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/LocalFileNode.java
@@ -116,8 +116,13 @@ public class LocalFileNode extends AbstractAbstractFileNode<AbstractFile> {
         return true; //!this.hasContentChildren();
     }
 
-    @Override
-    public String getItemType() {
-        return "LocalFile"; //NON-NLS
-    }
+    /*
+     * TODO (AUT-1849): Correct or remove peristent column reordering code
+     *
+     * Added to support this feature.
+     */
+//    @Override
+//    public String getItemType() {
+//        return "LocalFile"; //NON-NLS
+//    }
 }

--- a/Core/src/org/sleuthkit/autopsy/datamodel/RecentFilesFilterNode.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/RecentFilesFilterNode.java
@@ -83,8 +83,13 @@ public class RecentFilesFilterNode extends DisplayableItemNode {
         return true;
     }
 
-    @Override
-    public String getItemType() {
-        return "RecentFilesFilter"; //NON-NLS
-    }
+    /*
+     * TODO (AUT-1849): Correct or remove peristent column reordering code
+     *
+     * Added to support this feature.
+     */
+//    @Override
+//    public String getItemType() {
+//        return "RecentFilesFilter"; //NON-NLS
+//    }
 }

--- a/Core/src/org/sleuthkit/autopsy/datamodel/RecentFilesNode.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/RecentFilesNode.java
@@ -66,8 +66,13 @@ public class RecentFilesNode extends DisplayableItemNode {
         return s;
     }
 
-    @Override
-    public String getItemType() {
-        return "RecentFiles"; //NON-NLS
-    }
+    /*
+     * TODO (AUT-1849): Correct or remove peristent column reordering code
+     *
+     * Added to support this feature.
+     */
+//    @Override
+//    public String getItemType() {
+//        return "RecentFiles"; //NON-NLS
+//    }
 }

--- a/Core/src/org/sleuthkit/autopsy/datamodel/Reports.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/Reports.java
@@ -89,10 +89,15 @@ public final class Reports implements AutopsyVisitableItem {
             return visitor.visit(this);
         }
 
-        @Override
-        public String getItemType() {
-            return "ReportsList"; //NON-NLS
-        }
+        /*
+         * TODO (AUT-1849): Correct or remove peristent column reordering code
+         *
+         * Added to support this feature.
+         */
+//        @Override
+//        public String getItemType() {
+//            return "ReportsList"; //NON-NLS
+//        }
     }
 
     /**
@@ -214,11 +219,15 @@ public final class Reports implements AutopsyVisitableItem {
             return new OpenReportAction();
         }
 
-        @Override
-        public String getItemType() {
-            return "Reports"; //NON-NLS
-        }
-
+        /*
+         * TODO (AUT-1849): Correct or remove peristent column reordering code
+         *
+         * Added to support this feature.
+         */
+//        @Override
+//        public String getItemType() {
+//            return "Reports"; //NON-NLS
+//        }
         private static class DeleteReportAction extends AbstractAction {
 
             private static DeleteReportAction instance;

--- a/Core/src/org/sleuthkit/autopsy/datamodel/ResultsNode.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/ResultsNode.java
@@ -69,8 +69,13 @@ public class ResultsNode extends DisplayableItemNode {
         return s;
     }
 
-    @Override
-    public String getItemType() {
-        return "Results"; //NON-NLS
-    }
+    /*
+     * TODO (AUT-1849): Correct or remove peristent column reordering code
+     *
+     * Added to support this feature.
+     */
+//    @Override
+//    public String getItemType() {
+//        return "Results"; //NON-NLS
+//    }
 }

--- a/Core/src/org/sleuthkit/autopsy/datamodel/Tags.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/Tags.java
@@ -109,10 +109,15 @@ public class Tags implements AutopsyVisitableItem {
             return propertySheet;
         }
 
-        @Override
-        public String getItemType() {
-            return "TagsRoots"; //NON-NLS
-        }
+        /*
+         * TODO (AUT-1849): Correct or remove peristent column reordering code
+         *
+         * Added to support this feature.
+         */
+//        @Override
+//        public String getItemType() {
+//            return "TagsRoots"; //NON-NLS
+//        }
     }
 
     private class TagNameNodeFactory extends ChildFactory.Detachable<TagName> implements Observer {
@@ -271,10 +276,15 @@ public class Tags implements AutopsyVisitableItem {
             updateDisplayName();
         }
 
-        @Override
-        public String getItemType() {
-            return "TagsName"; //NON-NLS
-        }
+        /*
+         * TODO (AUT-1849): Correct or remove peristent column reordering code
+         *
+         * Added to support this feature.
+         */
+//        @Override
+//        public String getItemType() {
+//            return "TagsName"; //NON-NLS
+//        }
     }
 
     /**
@@ -371,10 +381,15 @@ public class Tags implements AutopsyVisitableItem {
             updateDisplayName();
         }
 
-        @Override
-        public String getItemType() {
-            return "TagsContentType"; //NON-NLS
-        }
+        /*
+         * TODO (AUT-1849): Correct or remove peristent column reordering code
+         *
+         * Added to support this feature.
+         */
+//        @Override
+//        public String getItemType() {
+//            return "TagsContentType"; //NON-NLS
+//        }
     }
 
     private class ContentTagNodeFactory extends ChildFactory<ContentTag> implements Observer {
@@ -469,10 +484,15 @@ public class Tags implements AutopsyVisitableItem {
             updateDisplayName();
         }
 
-        @Override
-        public String getItemType() {
-            return "TagsBlackboardArtifact"; //NON-NLS
-        }
+        /*
+         * TODO (AUT-1849): Correct or remove peristent column reordering code
+         *
+         * Added to support this feature.
+         */
+//        @Override
+//        public String getItemType() {
+//            return "TagsBlackboardArtifact"; //NON-NLS
+//        }
     }
 
     private class BlackboardArtifactTagNodeFactory extends ChildFactory<BlackboardArtifactTag> implements Observer {

--- a/Core/src/org/sleuthkit/autopsy/datamodel/ViewsNode.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/ViewsNode.java
@@ -73,8 +73,13 @@ public class ViewsNode extends DisplayableItemNode {
         return s;
     }
 
-    @Override
-    public String getItemType() {
-        return "Views"; //NON-NLS
-    }
+    /*
+     * TODO (AUT-1849): Correct or remove peristent column reordering code
+     *
+     * Added to support this feature.
+     */
+//    @Override
+//    public String getItemType() {
+//        return "Views"; //NON-NLS
+//    }
 }

--- a/Core/src/org/sleuthkit/autopsy/datamodel/VirtualDirectoryNode.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/VirtualDirectoryNode.java
@@ -149,8 +149,13 @@ public class VirtualDirectoryNode extends AbstractAbstractFileNode<VirtualDirect
         return result;
     }
 
-    @Override
-    public String getItemType() {
-        return "VirtualDirectory"; //NON-NLS
-    }
+    /*
+     * TODO (AUT-1849): Correct or remove peristent column reordering code
+     *
+     * Added to support this feature.
+     */
+//    @Override
+//    public String getItemType() {
+//        return "VirtualDirectory"; //NON-NLS
+//    }
 }

--- a/Core/src/org/sleuthkit/autopsy/datamodel/VolumeNode.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/VolumeNode.java
@@ -74,7 +74,7 @@ public class VolumeNode extends AbstractContentNode<Volume> {
         // Listen for case events so that we can detect when case is closed
         Case.addPropertyChangeListener(pcl);
     }
-    
+
     private void removeListeners() {
         IngestManager.getInstance().removeIngestModuleEventListener(pcl);
         Case.removePropertyChangeListener(pcl);
@@ -190,8 +190,13 @@ public class VolumeNode extends AbstractContentNode<Volume> {
         return v.visit(this);
     }
 
-    @Override
-    public String getItemType() {
-        return "Volume"; //NON-NLS
-    }
+    /*
+     * TODO (AUT-1849): Correct or remove peristent column reordering code
+     *
+     * Added to support this feature.
+     */
+//    @Override
+//    public String getItemType() {
+//        return "Volume"; //NON-NLS
+//    }
 }

--- a/Core/src/org/sleuthkit/autopsy/directorytree/DirectoryTreeTopComponent.java
+++ b/Core/src/org/sleuthkit/autopsy/directorytree/DirectoryTreeTopComponent.java
@@ -631,11 +631,18 @@ public final class DirectoryTreeTopComponent extends TopComponent implements Dat
                         //set node, wrap in filter node first to filter out children
                         Node drfn = new DataResultFilterNode(originNode, DirectoryTreeTopComponent.this.em);
                         Node kffn = new KnownFileFilterNode(drfn, KnownFileFilterNode.getSelectionContext(originNode));
-                        if(originNode instanceof DisplayableItemNode) {
-                            dataResult.setNode(new TableFilterNode(kffn, true, ((DisplayableItemNode) originNode).getItemType()));
-                        } else {
-                            dataResult.setNode(new TableFilterNode(kffn, true));
-                        }
+                        /*
+                         * TODO (AUT-1849): Correct or remove peristent column
+                         * reordering code
+                         *
+                         * The following conditional was added to support this
+                         * feature.
+                         */
+//                        if(originNode instanceof DisplayableItemNode) {
+//                            dataResult.setNode(new TableFilterNode(kffn, true, ((DisplayableItemNode) originNode).getItemType()));
+//                        } else {
+                        dataResult.setNode(new TableFilterNode(kffn, true));
+//                        }
 
                         String displayName = "";
                         Content content = originNode.getLookup().lookup(Content.class);
@@ -772,7 +779,7 @@ public final class DirectoryTreeTopComponent extends TopComponent implements Dat
 
         Node imagesNode = imagesNodeOrig.getNode();
 
-        DataSourcesNode.DataSourcesNodeChildren contentRootChildren = (DataSourcesNode.DataSourcesNodeChildren) imagesNode.getChildren();        
+        DataSourcesNode.DataSourcesNodeChildren contentRootChildren = (DataSourcesNode.DataSourcesNodeChildren) imagesNode.getChildren();
         contentRootChildren.refreshContentKeys();
 
         //final TreeView tree = getTree();

--- a/Core/src/org/sleuthkit/autopsy/timeline/explorernodes/EventNode.java
+++ b/Core/src/org/sleuthkit/autopsy/timeline/explorernodes/EventNode.java
@@ -121,11 +121,15 @@ class EventNode extends DisplayableItemNode {
         throw new UnsupportedOperationException("Not supported yet."); // NON-NLS //To change body of generated methods, choose Tools | Templates.
     }
 
-    @Override
-    public String getItemType() {
-        return "Event";
-    }
-
+    /*
+     * TODO (AUT-1849): Correct or remove peristent column reordering code
+     *
+     * Added to support this feature.
+     */
+//    @Override
+//    public String getItemType() {
+//        return "Event";
+//    }
     /**
      * We use TimeProperty instead of a normal NodeProperty to correctly display
      * the date/time when the user changes the timezone setting.

--- a/Core/src/org/sleuthkit/autopsy/timeline/explorernodes/EventRootNode.java
+++ b/Core/src/org/sleuthkit/autopsy/timeline/explorernodes/EventRootNode.java
@@ -70,10 +70,15 @@ public class EventRootNode extends DisplayableItemNode {
         return childCount;
     }
 
-    @Override
-    public String getItemType() {
-        return "EventRoot";
-    }
+    /*
+     * TODO (AUT-1849): Correct or remove peristent column reordering code
+     *
+     * Added to support this feature.
+     */
+//    @Override
+//    public String getItemType() {
+//        return "EventRoot";
+//    }
 
     /**
      * The node factories used to make lists of files to send to the result


### PR DESCRIPTION
We needed to disable or remove this feature for Autopsy release 4.0.1. I found it impractical to revert the work previously done, as it was in multiple commits spread over something like six weeks, which would also make it difficult to recover. So I decided to comment out the code that was added for this feature, while restoring some code that was removed or altered.  This is intended to be a temporary expedient until this story is worked in earnest, i.e., the code for this feature is repaired or , now clearly marked, removed.

All of the relevant code is tagged with comments of the form:

    /*
     * TODO (AUT-1849): Correct or remove peristent column reordering code
     *
     * [Explanatory remark(s) here]
     */
