### PR TITLE
refactor DrawableFile so it no longer extends AbstractFile

### DIFF
--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/ImageGalleryController.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/ImageGalleryController.java
@@ -441,7 +441,7 @@ public final class ImageGalleryController implements Executor {
     }
 
     @Nullable
-    synchronized public DrawableFile<?> getFileFromId(Long fileID) throws TskCoreException {
+    synchronized public DrawableFile getFileFromId(Long fileID) throws TskCoreException {
         if (Objects.isNull(db)) {
             LOGGER.log(Level.WARNING, "Could not get file from id, no DB set.  The case is probably closed."); //NON-NLS
             return null;
@@ -662,7 +662,7 @@ public final class ImageGalleryController implements Executor {
         @Override
         public void run() {
             try {
-                DrawableFile<?> drawableFile = DrawableFile.create(getFile(), true, getTaskDB().isVideoFile(getFile()));
+                DrawableFile drawableFile = DrawableFile.create(getFile(), true, false);
                 getTaskDB().updateFile(drawableFile);
             } catch (NullPointerException ex) {
                 // This is one of the places where we get many errors if the case is closed during processing.

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/ThumbnailCache.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/ThumbnailCache.java
@@ -97,7 +97,7 @@ public enum ThumbnailCache {
      *         could not be generated
      */
     @Nullable
-    public Image get(DrawableFile<?> file) {
+    public Image get(DrawableFile file) {
         try {
             return cache.get(file.getId(), () -> load(file));
         } catch (UncheckedExecutionException | CacheLoader.InvalidCacheLoadException | ExecutionException ex) {
@@ -124,9 +124,9 @@ public enum ThumbnailCache {
      *
      * @return an (possibly empty) optional containing a thumbnail
      */
-    private Image load(DrawableFile<?> file) {
+    private Image load(DrawableFile file) {
 
-        if (FileTypeUtils.isGIF(file)) {
+        if (FileTypeUtils.isGIF(file.getAbstractFile())) {
             //directly read gif to preserve potential animation,
             //NOTE: not saved to disk!
             return new Image(new BufferedInputStream(new ReadContentInputStream(file.getAbstractFile())), MAX_THUMBNAIL_SIZE, MAX_THUMBNAIL_SIZE, true, true);
@@ -171,7 +171,7 @@ public enum ThumbnailCache {
      * @return a Optional containing a File to store the cached icon in or an
      *         empty optional if there was a problem.
      */
-    private static Optional<File> getCacheFile(DrawableFile<?> file) {
+    private static Optional<File> getCacheFile(DrawableFile file) {
         try {
             return Optional.of(ImageUtils.getCachedThumbnailFile(file.getAbstractFile(), MAX_THUMBNAIL_SIZE));
 
@@ -181,7 +181,7 @@ public enum ThumbnailCache {
         }
     }
 
-    public Task<Image> getThumbnailTask(DrawableFile<?> file) {
+    public Task<Image> getThumbnailTask(DrawableFile file) {
         final Image thumbnail = cache.getIfPresent(file.getId());
         if (thumbnail != null) {
             return TaskUtils.taskFrom(() -> thumbnail);

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/actions/AddDrawableTagAction.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/actions/AddDrawableTagAction.java
@@ -28,7 +28,6 @@ import javafx.application.Platform;
 import javafx.scene.control.Alert;
 import javafx.scene.control.Menu;
 import javax.swing.SwingWorker;
-
 import org.openide.util.NbBundle;
 import org.openide.util.Utilities;
 import org.sleuthkit.autopsy.coreutils.Logger;
@@ -85,12 +84,12 @@ public class AddDrawableTagAction extends AddTagAction {
             protected Void doInBackground() throws Exception {
                 for (Long fileID : selectedFiles) {
                     try {
-                        final DrawableFile<?> file = controller.getFileFromId(fileID);
+                        final DrawableFile file = controller.getFileFromId(fileID);
                         LOGGER.log(Level.INFO, "tagging {0} with {1} and comment {2}", new Object[]{file.getName(), tagName.getDisplayName(), comment}); //NON-NLS
 
                         // check if the same tag is being added for the same abstract file.
                         DrawableTagsManager tagsManager = controller.getTagsManager();
-                        List<ContentTag> contentTags = tagsManager.getContentTagsByContent(file);
+                        List<ContentTag> contentTags = tagsManager.getContentTags(file);
                         Optional<TagName> duplicateTagName = contentTags.stream()
                                 .map(ContentTag::getName)
                                 .filter(tagName::equals)

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/actions/CategorizeAction.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/actions/CategorizeAction.java
@@ -35,7 +35,6 @@ import javafx.scene.input.KeyCodeCombination;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
 import javax.swing.JOptionPane;
-
 import org.openide.util.NbBundle;
 import org.sleuthkit.autopsy.coreutils.Logger;
 import org.sleuthkit.autopsy.imagegallery.ImageGalleryController;
@@ -146,7 +145,7 @@ public class CategorizeAction extends AddTagAction {
             Map<Long, TagName> oldCats = new HashMap<>();
             for (long fileID : fileIDs) {
                 try {
-                    DrawableFile<?> file = controller.getFileFromId(fileID);   //drawable db access
+                    DrawableFile file = controller.getFileFromId(fileID);   //drawable db access
                     if (createUndo) {
                         Category oldCat = file.getCategory();  //drawable db access
                         TagName oldCatTagName = categoryManager.getTagName(oldCat);
@@ -155,7 +154,7 @@ public class CategorizeAction extends AddTagAction {
                         }
                     }
 
-                    final List<ContentTag> fileTags = tagsManager.getContentTagsByContent(file);
+                    final List<ContentTag> fileTags = tagsManager.getContentTags(file);
                     if (tagName == categoryManager.getTagName(Category.ZERO)) {
                         // delete all cat tags for cat-0
                         fileTags.stream()

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/actions/DeleteFollowUpTagAction.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/actions/DeleteFollowUpTagAction.java
@@ -40,7 +40,7 @@ public class DeleteFollowUpTagAction extends Action {
     private static final Logger LOGGER = Logger.getLogger(DeleteFollowUpTagAction.class.getName());
 
     @NbBundle.Messages("DeleteFollwUpTagAction.displayName=Delete Follow Up Tag")
-    public DeleteFollowUpTagAction(final ImageGalleryController controller, final DrawableFile<?> file) {
+    public DeleteFollowUpTagAction(final ImageGalleryController controller, final DrawableFile file) {
         super(Bundle.DeleteFollwUpTagAction_displayName());
         setEventHandler((ActionEvent t) -> {
             new SwingWorker<Void, Void>() {
@@ -52,7 +52,7 @@ public class DeleteFollowUpTagAction extends Action {
                     try {
                         final TagName followUpTagName = tagsManager.getFollowUpTagName();
 
-                        List<ContentTag> contentTagsByContent = tagsManager.getContentTagsByContent(file);
+                        List<ContentTag> contentTagsByContent = tagsManager.getContentTags(file);
                         for (ContentTag ct : contentTagsByContent) {
                             if (ct.getName().getDisplayName().equals(followUpTagName.getDisplayName())) {
                                 tagsManager.deleteContentTag(ct);

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/actions/OpenExternalViewerAction.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/actions/OpenExternalViewerAction.java
@@ -39,7 +39,7 @@ public class OpenExternalViewerAction extends Action {
     private static final Image EXTERNAL = new Image(OpenExternalViewerAction.class.getResource("/org/sleuthkit/autopsy/imagegallery/images/external.png").toExternalForm()); //NON-NLS
     private static final ActionEvent ACTION_EVENT = new ActionEvent(OpenExternalViewerAction.class, ActionEvent.ACTION_PERFORMED, ""); //Swing ActionEvent //NOI18N
 
-    public OpenExternalViewerAction(DrawableFile<?> file) {
+    public OpenExternalViewerAction(DrawableFile file) {
         super(Bundle.OpenExternalViewerAction_displayName());
 
         /**

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/CategoryManager.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/CategoryManager.java
@@ -248,7 +248,7 @@ public class CategoryManager {
             final DrawableTagsManager tagsManager = controller.getTagsManager();
             try {
                 //remove old category tag(s) if necessary
-                for (ContentTag ct : tagsManager.getContentTagsByContent(addedTag.getContent())) {
+                for (ContentTag ct : tagsManager.getContentTags(addedTag.getContent())) {
                     if (ct.getId() != addedTag.getId()
                             && CategoryManager.isCategoryTagName(ct.getName())) {
                         try {

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/DrawableAttribute.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/DrawableAttribute.java
@@ -111,13 +111,13 @@ public class DrawableAttribute<T extends Comparable<T>> {
             new DrawableAttribute<>(AttributeName.CREATED_TIME, Bundle.DrawableAttribute_createdTime(),
                     true,
                     "clock--plus.png", //NON-NLS
-                    f -> Collections.singleton(ContentUtils.getStringTime(f.getCrtime(), f)));
+                    f -> Collections.singleton(ContentUtils.getStringTime(f.getCrtime(), f.getAbstractFile())));
 
     public final static DrawableAttribute<String> MODIFIED_TIME =
             new DrawableAttribute<>(AttributeName.MODIFIED_TIME, Bundle.DrawableAttribute_modifiedTime(),
                     true,
                     "clock--pencil.png", //NON-NLS
-                    f -> Collections.singleton(ContentUtils.getStringTime(f.getMtime(), f)));
+                    f -> Collections.singleton(ContentUtils.getStringTime(f.getMtime(), f.getAbstractFile())));
 
     public final static DrawableAttribute<String> MAKE =
             new DrawableAttribute<>(AttributeName.MAKE, Bundle.DrawableAttribute_cameraMake(),
@@ -168,9 +168,9 @@ public class DrawableAttribute<T extends Comparable<T>> {
             Arrays.asList(NAME, ANALYZED, CATEGORY, TAGS, PATH, CREATED_TIME,
                     MODIFIED_TIME, MD5_HASH, HASHSET, MAKE, MODEL, OBJ_ID, WIDTH, HEIGHT, MIME_TYPE);
 
-    private final Function<DrawableFile<?>, Collection<T>> extractor;
+    private final Function<DrawableFile, Collection<T>> extractor;
 
-    private DrawableAttribute(AttributeName name, String displayName, Boolean isDBColumn, String imageName, Function<DrawableFile<?>, Collection<T>> extractor) {
+    private DrawableAttribute(AttributeName name, String displayName, Boolean isDBColumn, String imageName, Function<DrawableFile, Collection<T>> extractor) {
         this.attrName = name;
         this.displayName = new ReadOnlyStringWrapper(displayName);
         this.isDBColumn = isDBColumn;
@@ -223,7 +223,7 @@ public class DrawableAttribute<T extends Comparable<T>> {
         return displayName.get();
     }
 
-    public Collection<T> getValue(DrawableFile<?> f) {
+    public Collection<T> getValue(DrawableFile f) {
         return extractor.apply(f);
     }
 

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/DrawableDB.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/DrawableDB.java
@@ -569,23 +569,23 @@ public final class DrawableDB {
         return removeFile;
     }
 
-    public void updateFile(DrawableFile<?> f) {
+    public void updateFile(DrawableFile f) {
         DrawableTransaction trans = beginTransaction();
         updateFile(f, trans);
         commitTransaction(trans, true);
     }
 
-    public void insertFile(DrawableFile<?> f) {
+    public void insertFile(DrawableFile f) {
         DrawableTransaction trans = beginTransaction();
         insertFile(f, trans);
         commitTransaction(trans, true);
     }
 
-    public void insertFile(DrawableFile<?> f, DrawableTransaction tr) {
+    public void insertFile(DrawableFile f, DrawableTransaction tr) {
         insertOrUpdateFile(f, tr, insertFileStmt);
     }
 
-    public void updateFile(DrawableFile<?> f, DrawableTransaction tr) {
+    public void updateFile(DrawableFile f, DrawableTransaction tr) {
         insertOrUpdateFile(f, tr, updateFileStmt);
     }
 
@@ -602,7 +602,7 @@ public final class DrawableDB {
      * @param tr   a transaction to use, must not be null
      * @param stmt the statement that does the actull inserting
      */
-    private void insertOrUpdateFile(DrawableFile<?> f, @Nonnull DrawableTransaction tr, @Nonnull PreparedStatement stmt) {
+    private void insertOrUpdateFile(DrawableFile f, @Nonnull DrawableTransaction tr, @Nonnull PreparedStatement stmt) {
 
         if (tr.isClosed()) {
             throw new IllegalArgumentException("can't update database with closed transaction");
@@ -686,7 +686,7 @@ public final class DrawableDB {
         tr.commit(notify);
     }
 
-    public Boolean isFileAnalyzed(DrawableFile<?> f) {
+    public Boolean isFileAnalyzed(DrawableFile f) {
         return isFileAnalyzed(f.getId());
     }
 
@@ -984,7 +984,7 @@ public final class DrawableDB {
      * @throws TskCoreException if unable to get a file from the currently open
      *                          {@link SleuthkitCase}
      */
-    private DrawableFile<?> getFileFromID(Long id, boolean analyzed) throws TskCoreException {
+    private DrawableFile getFileFromID(Long id, boolean analyzed) throws TskCoreException {
         try {
             AbstractFile f = tskCase.getAbstractFileById(id);
             return DrawableFile.create(f, analyzed, isVideoFile(f));
@@ -1002,7 +1002,7 @@ public final class DrawableDB {
      * @throws TskCoreException if unable to get a file from the currently open
      *                          {@link SleuthkitCase}
      */
-    public DrawableFile<?> getFileFromID(Long id) throws TskCoreException {
+    public DrawableFile getFileFromID(Long id) throws TskCoreException {
         try {
             AbstractFile f = tskCase.getAbstractFileById(id);
             return DrawableFile.create(f,

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/DrawableFile.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/DrawableFile.java
@@ -19,6 +19,7 @@
 package org.sleuthkit.autopsy.imagegallery.datamodel;
 
 import java.lang.ref.SoftReference;
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -42,39 +43,36 @@ import org.sleuthkit.autopsy.imagegallery.ThumbnailCache;
 import org.sleuthkit.autopsy.imagegallery.utils.TaskUtils;
 import org.sleuthkit.datamodel.AbstractFile;
 import org.sleuthkit.datamodel.BlackboardArtifact;
+import org.sleuthkit.datamodel.BlackboardArtifact.ARTIFACT_TYPE;
 import org.sleuthkit.datamodel.BlackboardAttribute;
-import org.sleuthkit.datamodel.Content;
-import org.sleuthkit.datamodel.ContentVisitor;
-import org.sleuthkit.datamodel.ReadContentInputStream;
-import org.sleuthkit.datamodel.SleuthkitItemVisitor;
+import org.sleuthkit.datamodel.BlackboardAttribute.ATTRIBUTE_TYPE;
+import org.sleuthkit.datamodel.ContentTag;
+import org.sleuthkit.datamodel.SleuthkitCase;
 import org.sleuthkit.datamodel.Tag;
 import org.sleuthkit.datamodel.TagName;
 import org.sleuthkit.datamodel.TskCoreException;
 
 /**
- * @TODO: There is something I don't understand or have done wrong about
- * implementing this class,as it is unreadable by
- * {@link ReadContentInputStream}. As a work around we keep a reference to the
- * original {@link AbstractFile} to use when reading the image. -jm
+ * A file that contains visual information such as an image or video.
  */
-public abstract class DrawableFile<T extends AbstractFile> extends AbstractFile {
+public abstract class DrawableFile {
 
     private static final Logger LOGGER = Logger.getLogger(DrawableFile.class.getName());
 
-    public static DrawableFile<?> create(AbstractFile abstractFileById, boolean analyzed) {
+    public static DrawableFile create(AbstractFile abstractFileById, boolean analyzed) {
         return create(abstractFileById, analyzed, FileTypeUtils.isVideoFile(abstractFileById));
     }
 
     /**
      * Skip the database query if we have already determined the file type.
      */
-    public static DrawableFile<?> create(AbstractFile abstractFileById, boolean analyzed, boolean isVideo) {
+    public static DrawableFile create(AbstractFile abstractFileById, boolean analyzed, boolean isVideo) {
         return isVideo
-                ? new VideoFile<>(abstractFileById, analyzed)
-                : new ImageFile<>(abstractFileById, analyzed);
+                ? new VideoFile(abstractFileById, analyzed)
+                : new ImageFile(abstractFileById, analyzed);
     }
 
-    public static DrawableFile<?> create(Long id, boolean analyzed) throws TskCoreException, IllegalStateException {
+    public static DrawableFile create(Long id, boolean analyzed) throws TskCoreException, IllegalStateException {
         return create(Case.getCurrentCase().getSleuthkitCase().getAbstractFileById(id), analyzed);
     }
 
@@ -82,7 +80,7 @@ public abstract class DrawableFile<T extends AbstractFile> extends AbstractFile 
 
     private String drawablePath;
 
-    private final T file;
+    private final AbstractFile file;
 
     private final SimpleBooleanProperty analyzed;
 
@@ -92,72 +90,61 @@ public abstract class DrawableFile<T extends AbstractFile> extends AbstractFile 
 
     private String model;
 
-    protected DrawableFile(T file, Boolean analyzed) {
-        /*
-         * @TODO: the two 'new Integer(0).shortValue()' values and null are
-         * placeholders because the super constructor expects values i can't get
-         * easily at the moment. I assume this is related to why
-         * ReadContentInputStream can't read from DrawableFiles.
-         */
-
-        super(file.getSleuthkitCase(),
-                file.getId(),
-                file.getAttrType(),
-                file.getAttrId(),
-                file.getName(),
-                file.getType(),
-                file.getMetaAddr(),
-                (int) file.getMetaSeq(),
-                file.getDirType(),
-                file.getMetaType(),
-                null,
-                new Integer(0).shortValue(),
-                file.getSize(),
-                file.getCtime(),
-                file.getCrtime(),
-                file.getAtime(),
-                file.getMtime(),
-                new Integer(0).shortValue(),
-                file.getUid(),
-                file.getGid(),
-                file.getMd5Hash(),
-                file.getKnown(),
-                file.getParentPath());
+    protected DrawableFile(AbstractFile file, Boolean analyzed) {
         this.analyzed = new SimpleBooleanProperty(analyzed);
         this.file = file;
     }
 
     public abstract boolean isVideo();
 
-    @Override
-    public boolean isRoot() {
-        return false;
-    }
-
-    @Override
-    public <T> T accept(SleuthkitItemVisitor<T> v) {
-        return file.accept(v);
-    }
-
-    @Override
-    public <T> T accept(ContentVisitor<T> v) {
-        return file.accept(v);
-    }
-
-    @Override
-    public List<Content> getChildren() throws TskCoreException {
-        return new ArrayList<>();
-    }
-
-    @Override
-    public List<Long> getChildrenIds() throws TskCoreException {
-        return new ArrayList<>();
-    }
-
     public List<Pair<DrawableAttribute<?>, Collection<?>>> getAttributesList() {
         return DrawableAttribute.getValues().stream()
                 .map(this::makeAttributeValuePair)
                 .collect(Collectors.toList());
+    }
+
+    public String getMIMEType() {
+        return file.getMIMEType();
+    }
+
+    public long getId() {
+        return file.getId();
+    }
+
+    public long getCtime() {
+        return file.getCtime();
+    }
+
+    public long getCrtime() {
+        return file.getCrtime();
+    }
+
+    public long getAtime() {
+        return file.getAtime();
+    }
+
+    public long getMtime() {
+        return file.getMtime();
+    }
+
+    public String getMd5Hash() {
+        return file.getMd5Hash();
+    }
+
+    public String getName() {
+        return file.getName();
+    }
+
+    public String getAtimeAsDate() {
+        return file.getAtimeAsDate();
+    }
+
+    public synchronized String getUniquePath() throws TskCoreException {
+        return file.getUniquePath();
+    }
+
+    public SleuthkitCase getSleuthkitCase() {
+        return file.getSleuthkitCase();
     }
 
     private Pair<DrawableAttribute<?>, Collection<?>> makeAttributeValuePair(DrawableAttribute<?> t) {
@@ -166,14 +153,14 @@ public abstract class DrawableFile<T extends AbstractFile> extends AbstractFile 
 
     public String getModel() {
         if (model == null) {
-            model = WordUtils.capitalizeFully((String) getValueOfBBAttribute(BlackboardArtifact.ARTIFACT_TYPE.TSK_METADATA_EXIF, BlackboardAttribute.ATTRIBUTE_TYPE.TSK_DEVICE_MODEL));
+            model = WordUtils.capitalizeFully((String) getValueOfBBAttribute(ARTIFACT_TYPE.TSK_METADATA_EXIF, ATTRIBUTE_TYPE.TSK_DEVICE_MODEL));
         }
         return model;
     }
 
     public String getMake() {
         if (make == null) {
-            make = WordUtils.capitalizeFully((String) getValueOfBBAttribute(BlackboardArtifact.ARTIFACT_TYPE.TSK_METADATA_EXIF, BlackboardAttribute.ATTRIBUTE_TYPE.TSK_DEVICE_MAKE));
+            make = WordUtils.capitalizeFully((String) getValueOfBBAttribute(ARTIFACT_TYPE.TSK_METADATA_EXIF, ATTRIBUTE_TYPE.TSK_DEVICE_MAKE));
         }
         return make;
     }
@@ -181,18 +168,18 @@ public abstract class DrawableFile<T extends AbstractFile> extends AbstractFile 
     public Set<TagName> getTagNames() {
         try {
 
-            return getSleuthkitCase().getContentTagsByContent(this).stream()
+            return getContentTags().stream()
                     .map(Tag::getName)
                     .collect(Collectors.toSet());
         } catch (TskCoreException ex) {
             Logger.getAnonymousLogger().log(Level.WARNING, "problem looking up " + DrawableAttribute.TAGS.getDisplayName() + " for " + file.getName(), ex); //NON-NLS
         } catch (IllegalStateException ex) {
-            Logger.getAnonymousLogger().log(Level.WARNING, "there is no case open; failed to look up " + DrawableAttribute.TAGS.getDisplayName() + " for " + file.getName()); //NON-NLS
+            Logger.getAnonymousLogger().log(Level.WARNING, "there is no case open; failed to look up " + DrawableAttribute.TAGS.getDisplayName() + " for " + getContentPathSafe(), ex); //NON-NLS
         }
         return Collections.emptySet();
     }
 
-    protected Object getValueOfBBAttribute(BlackboardArtifact.ARTIFACT_TYPE artType, BlackboardAttribute.ATTRIBUTE_TYPE attrType) {
+    protected Object getValueOfBBAttribute(ARTIFACT_TYPE artType, ATTRIBUTE_TYPE attrType) {
         try {
 
             //why doesn't file.getArtifacts() work?
@@ -222,7 +209,8 @@ public abstract class DrawableFile<T extends AbstractFile> extends AbstractFile 
                 }
             }
         } catch (TskCoreException ex) {
-            Logger.getAnonymousLogger().log(Level.WARNING, "problem looking up {0}/{1}" + " " + " for {2}", new Object[]{artType.getDisplayName(), attrType.getDisplayName(), getName()}); //NON-NLS
+            Logger.getAnonymousLogger().log(Level.WARNING, ex,
+                    () -> MessageFormat.format("problem looking up {0}/{1}" + " " + " for {2}", new Object[]{artType.getDisplayName(), attrType.getDisplayName(), getContentPathSafe()})); //NON-NLS
         }
         return "";
     }
@@ -246,7 +234,7 @@ public abstract class DrawableFile<T extends AbstractFile> extends AbstractFile 
      */
     private void updateCategory() {
         try {
-            category.set(getSleuthkitCase().getContentTagsByContent(this).stream()
+            category.set(getContentTags().stream()
                     .map(Tag::getName).filter(CategoryManager::isCategoryTagName)
                     .map(TagName::getDisplayName)
                     .map(Category::fromDisplayName)
@@ -254,10 +242,14 @@ public abstract class DrawableFile<T extends AbstractFile> extends AbstractFile 
                     .orElse(Category.ZERO)
             );
         } catch (TskCoreException ex) {
-            LOGGER.log(Level.WARNING, "problem looking up category for file " + this.getName() + ex.getLocalizedMessage()); //NON-NLS
+            LOGGER.log(Level.WARNING, "problem looking up category for " + this.getContentPathSafe(), ex); //NON-NLS
         } catch (IllegalStateException ex) {
             // We get here many times if the case is closed during ingest, so don't print out a ton of warnings.
         }
+    }
+
+    private List<ContentTag> getContentTags() throws TskCoreException {
+        return getSleuthkitCase().getContentTagsByContent(file);
     }
 
     @Deprecated
@@ -316,7 +308,7 @@ public abstract class DrawableFile<T extends AbstractFile> extends AbstractFile 
         return analyzed.get();
     }
 
-    public T getAbstractFile() {
+    public AbstractFile getAbstractFile() {
         return this.file;
     }
 
@@ -332,10 +324,14 @@ public abstract class DrawableFile<T extends AbstractFile> extends AbstractFile 
                 drawablePath = StringUtils.removeEnd(getUniquePath(), getName());
                 return drawablePath;
             } catch (TskCoreException ex) {
-                LOGGER.log(Level.WARNING, "failed to get drawablePath from {0}", getName()); //NON-NLS
+                LOGGER.log(Level.WARNING, "failed to get drawablePath from " + getContentPathSafe(), ex); //NON-NLS
                 return "";
             }
         }
+    }
+
+    public Set<String> getHashSetNames() throws TskCoreException {
+        return file.getHashSetNames();
     }
 
     @Nonnull
@@ -358,7 +354,7 @@ public abstract class DrawableFile<T extends AbstractFile> extends AbstractFile 
      */
     public String getContentPathSafe() {
         try {
-            return this.getUniquePath();
+            return getUniquePath();
         } catch (TskCoreException tskCoreException) {
             String contentName = this.getName();
             LOGGER.log(Level.SEVERE, "Failed to get unique path for " + contentName, tskCoreException); //NOI18N NON-NLS

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/DrawableTagsManager.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/DrawableTagsManager.java
@@ -164,19 +164,33 @@ public class DrawableTagsManager {
     }
 
     /**
-     * Gets content tags count by content.
+     * Gets content tags by content.
      *
-     * @param The content of interest.
+     * @param content The content of interest.
      *
      * @return A list, possibly empty, of the tags that have been applied to the
-     *         artifact.
+     *         content.
      *
-     * @throws TskCoreException
+     * @throws TskCoreException if there was an error reading from the db
      */
-    public List<ContentTag> getContentTagsByContent(Content content) throws TskCoreException {
+    public List<ContentTag> getContentTags(Content content) throws TskCoreException {
         synchronized (autopsyTagsManagerLock) {
             return autopsyTagsManager.getContentTagsByContent(content);
         }
+    }
+
+    /**
+     * Gets content tags by DrawableFile.
+     *
+     * @param drawable The DrawableFile of interest.
+     *
+     * @return A list, possibly empty, of the tags that have been applied to the
+     *         DrawableFile.
+     *
+     * @throws TskCoreException if there was an error reading from the db
+     */
+    public List<ContentTag> getContentTags(DrawableFile drawable) throws TskCoreException {
+        return getContentTags(drawable.getAbstractFile());
     }
 
     public TagName getTagName(String displayName) throws TskCoreException {
@@ -207,7 +221,7 @@ public class DrawableTagsManager {
         }
     }
 
-    public ContentTag addContentTag(DrawableFile<?> file, TagName tagName, String comment) throws TskCoreException {
+    public ContentTag addContentTag(DrawableFile file, TagName tagName, String comment) throws TskCoreException {
         synchronized (autopsyTagsManagerLock) {
             return autopsyTagsManager.addContentTag(file.getAbstractFile(), tagName, comment);
         }

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/ImageFile.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/ImageFile.java
@@ -21,7 +21,6 @@ package org.sleuthkit.autopsy.imagegallery.datamodel;
 import java.io.IOException;
 import javafx.concurrent.Task;
 import javafx.scene.image.Image;
-import javax.imageio.ImageIO;
 import org.sleuthkit.autopsy.coreutils.ImageUtils;
 import org.sleuthkit.autopsy.coreutils.Logger;
 import org.sleuthkit.datamodel.AbstractFile;
@@ -31,17 +30,12 @@ import org.sleuthkit.datamodel.AbstractFile;
  * wrapper(/decorator?/adapter?) around {@link AbstractFile} and provides
  * methods to get an thumbnail sized and a full sized {@link  Image}.
  */
-public class ImageFile<T extends AbstractFile> extends DrawableFile<T> {
+public class ImageFile extends DrawableFile {
 
     private static final Logger LOGGER = Logger.getLogger(ImageFile.class.getName());
 
-    static {
-        ImageIO.scanForPlugins();
-    }
-
-    ImageFile(T f, Boolean analyzed) {
+    ImageFile(AbstractFile f, Boolean analyzed) {
         super(f, analyzed);
-
     }
 
     @Override

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/VideoFile.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/VideoFile.java
@@ -36,13 +36,13 @@ import org.sleuthkit.autopsy.coreutils.VideoUtils;
 import org.sleuthkit.autopsy.datamodel.ContentUtils;
 import org.sleuthkit.datamodel.AbstractFile;
 
-public class VideoFile<T extends AbstractFile> extends DrawableFile<T> {
+public class VideoFile extends DrawableFile {
 
     private static final Logger LOGGER = Logger.getLogger(VideoFile.class.getName());
 
     private static final Image VIDEO_ICON = new Image("org/sleuthkit/autopsy/imagegallery/images/Clapperboard.png"); //NON-NLS
 
-    VideoFile(T file, Boolean analyzed) {
+    VideoFile(AbstractFile file, Boolean analyzed) {
         super(file, analyzed);
     }
 

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/grouping/GroupManager.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/grouping/GroupManager.java
@@ -169,7 +169,7 @@ public class GroupManager {
      * file is a part of
      */
     @SuppressWarnings({"rawtypes", "unchecked"})
-    synchronized public Set<GroupKey<?>> getGroupKeysForFile(DrawableFile<?> file) {
+    synchronized public Set<GroupKey<?>> getGroupKeysForFile(DrawableFile file) {
         Set<GroupKey<?>> resultSet = new HashSet<>();
         for (Comparable<?> val : groupBy.getValue(file)) {
             if (groupBy == DrawableAttribute.TAGS) {
@@ -193,7 +193,7 @@ public class GroupManager {
     synchronized public Set<GroupKey<?>> getGroupKeysForFileID(Long fileID) {
         try {
             if (nonNull(db)) {
-                DrawableFile<?> file = db.getFileFromID(fileID);
+                DrawableFile file = db.getFileFromID(fileID);
                 return getGroupKeysForFile(file);
             } else {
                 Logger.getLogger(GroupManager.class.getName()).log(Level.WARNING, "Failed to load file with id: {0} from database.  There is no database assigned.", fileID); //NON-NLS

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/gui/VideoPlayer.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/gui/VideoPlayer.java
@@ -104,7 +104,7 @@ public class VideoPlayer extends BorderPane {
             mp.seek(Duration.millis(timeSlider.getValue()));
         }
     };
-    private final VideoFile<?> file;
+    private final VideoFile file;
 
     @FXML
     @NbBundle.Messages({"# {0} - exception type",
@@ -236,7 +236,7 @@ public class VideoPlayer extends BorderPane {
         }
     }
 
-    public VideoPlayer(MediaPlayer mp, VideoFile<?> file) {
+    public VideoPlayer(MediaPlayer mp, VideoFile file) {
         this.file = file;
         this.mp = mp;
         FXMLConstructor.construct(this, "MediaControl.fxml"); //NON-NLS

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/gui/drawableviews/DrawableTile.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/gui/drawableviews/DrawableTile.java
@@ -31,13 +31,11 @@ import javafx.scene.image.Image;
 import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.paint.Color;
-import org.openide.util.NbBundle;
 import org.sleuthkit.autopsy.coreutils.Logger;
 import org.sleuthkit.autopsy.imagegallery.FXMLConstructor;
 import org.sleuthkit.autopsy.imagegallery.ImageGalleryController;
 import org.sleuthkit.autopsy.imagegallery.datamodel.DrawableFile;
 import org.sleuthkit.autopsy.imagegallery.gui.Toolbar;
-import org.sleuthkit.datamodel.AbstractContent;
 
 /**
  * GUI component that represents a single image as a tile with an icon, a label,
@@ -108,12 +106,12 @@ public class DrawableTile extends DrawableTileBase {
     }
 
     @Override
-    Task<Image> newReadImageTask(DrawableFile<?> file) {
+    Task<Image> newReadImageTask(DrawableFile file) {
         return file.getThumbnailTask();
     }
 
     @Override
     protected String getTextForLabel() {
-        return getFile().map(AbstractContent::getName).orElse("");
+        return getFile().map(DrawableFile::getName).orElse("");
     }
 }

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/gui/drawableviews/DrawableTileBase.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/gui/drawableviews/DrawableTileBase.java
@@ -179,7 +179,7 @@ public abstract class DrawableTileBase extends DrawableUIBase {
                 t.consume();
             }
 
-            private ContextMenu buildContextMenu(DrawableFile<?> file) {
+            private ContextMenu buildContextMenu(DrawableFile file) {
                 final ArrayList<MenuItem> menuItems = new ArrayList<>();
 
                 menuItems.add(new CategorizeAction(getController()).getPopupMenu());

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/gui/drawableviews/DrawableUIBase.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/gui/drawableviews/DrawableUIBase.java
@@ -66,7 +66,7 @@ abstract public class DrawableUIBase extends AnchorPane implements DrawableView 
 
     private final ImageGalleryController controller;
 
-    private Optional<DrawableFile<?>> fileOpt = Optional.empty();
+    private Optional<DrawableFile> fileOpt = Optional.empty();
 
     private Optional<Long> fileIDOpt = Optional.empty();
     private volatile Task<Image> imageTask;
@@ -89,12 +89,12 @@ abstract public class DrawableUIBase extends AnchorPane implements DrawableView 
         this.fileIDOpt = fileIDOpt;
     }
 
-    synchronized void setFileOpt(Optional<DrawableFile<?>> fileOpt) {
+    synchronized void setFileOpt(Optional<DrawableFile> fileOpt) {
         this.fileOpt = fileOpt;
     }
 
     @Override
-    synchronized public Optional<DrawableFile<?>> getFile() {
+    synchronized public Optional<DrawableFile> getFile() {
         if (fileIDOpt.isPresent()) {
             if (fileOpt.isPresent() && fileOpt.get().getId() == fileIDOpt.get()) {
                 return fileOpt;
@@ -131,7 +131,7 @@ abstract public class DrawableUIBase extends AnchorPane implements DrawableView 
         }
     }
 
-    synchronized Node doReadImageTask(DrawableFile<?> file) {
+    synchronized Node doReadImageTask(DrawableFile file) {
         Task<Image> myTask = newReadImageTask(file);
         imageTask = myTask;
         Node progressNode = newProgressIndicator(myTask);
@@ -191,7 +191,7 @@ abstract public class DrawableUIBase extends AnchorPane implements DrawableView 
     }
 
     @ThreadConfined(type = ThreadConfined.ThreadType.JFX)
-    private void showImage(DrawableFile<?> file, Task<Image> imageTask) {
+    private void showImage(DrawableFile file, Task<Image> imageTask) {
         //Note that all error conditions are allready logged in readImageTask.succeeded()
         try {
             Image fxImage = imageTask.get();
@@ -210,7 +210,7 @@ abstract public class DrawableUIBase extends AnchorPane implements DrawableView 
     }
 
     @ThreadConfined(type = ThreadConfined.ThreadType.JFX)
-    void showErrorNode(String errorMessage, DrawableFile<?> file) {
+    void showErrorNode(String errorMessage, DrawableFile file) {
         Button createButton = ActionUtils.createButton(new OpenExternalViewerAction(file));
 
         VBox vBox = new VBox(10, new Label(errorMessage), createButton);
@@ -218,5 +218,5 @@ abstract public class DrawableUIBase extends AnchorPane implements DrawableView 
         imageBorder.setCenter(vBox);
     }
 
-    abstract Task<Image> newReadImageTask(DrawableFile<?> file);
+    abstract Task<Image> newReadImageTask(DrawableFile file);
 }

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/gui/drawableviews/DrawableView.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/gui/drawableviews/DrawableView.java
@@ -52,7 +52,7 @@ public interface DrawableView {
 
     Region getCategoryBorderRegion();
 
-    Optional<DrawableFile<?>> getFile();
+    Optional<DrawableFile> getFile();
 
     void setFile(final Long fileID);
 

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/gui/drawableviews/GroupPane.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/gui/drawableviews/GroupPane.java
@@ -306,7 +306,7 @@ public class GroupPane extends BorderPane {
 
     }
 
-    void syncCatToggle(DrawableFile<?> file) {
+    void syncCatToggle(DrawableFile file) {
         getToggleForCategory(file.getCategory()).setSelected(true);
     }
 

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/gui/drawableviews/MetaDataPane.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/gui/drawableviews/MetaDataPane.java
@@ -201,7 +201,7 @@ public class MetaDataPane extends DrawableUIBase {
     }
 
     @Override
-    Task<Image> newReadImageTask(DrawableFile<?> file) {
+    Task<Image> newReadImageTask(DrawableFile file) {
         return file.getThumbnailTask();
     }
 

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/gui/drawableviews/SlideShowView.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/gui/drawableviews/SlideShowView.java
@@ -56,7 +56,6 @@ import org.sleuthkit.autopsy.imagegallery.datamodel.VideoFile;
 import org.sleuthkit.autopsy.imagegallery.gui.VideoPlayer;
 import static org.sleuthkit.autopsy.imagegallery.gui.drawableviews.DrawableUIBase.exec;
 import static org.sleuthkit.autopsy.imagegallery.gui.drawableviews.DrawableView.CAT_BORDER_WIDTH;
-import org.sleuthkit.datamodel.AbstractContent;
 
 /**
  * Displays the files of a group one at a time. Designed to be embedded in a
@@ -186,16 +185,16 @@ public class SlideShowView extends DrawableTileBase {
     synchronized protected void updateContent() {
         disposeContent();
         if (getFile().isPresent()) {
-            DrawableFile<?> file = getFile().get();
+            DrawableFile file = getFile().get();
             if (file.isVideo()) {
-                doMediaLoadTask((VideoFile<?>) file);
+                doMediaLoadTask((VideoFile) file);
             } else {
                 doReadImageTask(file);
             }
         }
     }
 
-    synchronized private Node doMediaLoadTask(VideoFile<?> file) {
+    synchronized private Node doMediaLoadTask(VideoFile file) {
 
         //specially handling for videos
         MediaLoadTask myTask = new MediaLoadTask(file);
@@ -225,7 +224,7 @@ public class SlideShowView extends DrawableTileBase {
     }
 
     @ThreadConfined(type = ThreadConfined.ThreadType.JFX)
-    private void showMedia(DrawableFile<?> file, Task<Node> mediaTask) {
+    private void showMedia(DrawableFile file, Task<Node> mediaTask) {
         //Note that all error conditions are allready logged in readImageTask.succeeded()
         try {
             Node mediaNode = mediaTask.get();
@@ -265,7 +264,7 @@ public class SlideShowView extends DrawableTileBase {
      */
     @Override
     protected String getTextForLabel() {
-        return getFile().map(AbstractContent::getName).orElse("") + " " + getSupplementalText();
+        return getFile().map(DrawableFile::getName).orElse("") + " " + getSupplementalText();
     }
 
     /**
@@ -308,7 +307,7 @@ public class SlideShowView extends DrawableTileBase {
     @Override
     @ThreadConfined(type = ThreadType.ANY)
     public Category updateCategory() {
-        Optional<DrawableFile<?>> file = getFile();
+        Optional<DrawableFile> file = getFile();
         if (file.isPresent()) {
             Category updateCategory = super.updateCategory();
             Platform.runLater(() -> getGroupPane().syncCatToggle(file.get()));
@@ -319,7 +318,7 @@ public class SlideShowView extends DrawableTileBase {
     }
 
     @Override
-    Task<Image> newReadImageTask(DrawableFile<?> file) {
+    Task<Image> newReadImageTask(DrawableFile file) {
         return file.getReadFullSizeImageTask();
 
     }
@@ -328,9 +327,9 @@ public class SlideShowView extends DrawableTileBase {
         "MediaLoadTask.messageText=Reading video: {0}"})
     private class MediaLoadTask extends Task<Node> {
 
-        private final VideoFile<?> file;
+        private final VideoFile file;
 
-        MediaLoadTask(VideoFile<?> file) {
+        MediaLoadTask(VideoFile file) {
             updateMessage(Bundle.MediaLoadTask_messageText(file.getName()));
             this.file = file;
         }


### PR DESCRIPTION
- remove type paramater from DrawableFile since it was not adding anything usefull and cluttered up the code
- add getters  that delegate to private AbastractFile instance
- refactor methods on DrawableTagsManager to deal with Content or DrawableFile objects
- remove unneeded  invocation of   ImageIO.scanForPlugins() in ImageFile