### PR TITLE
Close remote event channel in a way that allows it to be re-opened

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/casemodule/CollaborationMonitor.java
+++ b/Core/src/org/sleuthkit/autopsy/casemodule/CollaborationMonitor.java
@@ -466,7 +466,11 @@ final class CollaborationMonitor {
          */
         @Override
         public void run() {
-            eventPublisher.publishRemotely(new CollaborationEvent(hostName, localTasksManager.getCurrentTasks()));
+            try {
+                eventPublisher.publishRemotely(new CollaborationEvent(hostName, localTasksManager.getCurrentTasks()));
+            } catch (Exception ex) {
+                logger.log(Level.SEVERE, "Unexpected exception in HeartbeatTask!", ex); //NON-NLS
+            }
         }
     }
 
@@ -482,7 +486,11 @@ final class CollaborationMonitor {
          */
         @Override
         public void run() {
-            remoteTasksManager.finishStaleTasks();
+            try {
+                remoteTasksManager.finishStaleTasks();
+            } catch (Exception ex) {
+                logger.log(Level.SEVERE, "Unexpected exception in StaleTaskDetectionTask!", ex); //NON-NLS
+            }
         }
     }
 

--- a/Core/src/org/sleuthkit/autopsy/core/ServicesMonitor.java
+++ b/Core/src/org/sleuthkit/autopsy/core/ServicesMonitor.java
@@ -389,7 +389,11 @@ public class ServicesMonitor {
          */
         @Override
         public void run() {
-            checkAllServices();
+            try {
+                checkAllServices();
+            } catch (Exception ex) {
+                logger.log(Level.SEVERE, "Unexpected exception in CrashDetectionTask!", ex); //NON-NLS
+            }
         }
     }
 

--- a/Core/src/org/sleuthkit/autopsy/events/AutopsyEventPublisher.java
+++ b/Core/src/org/sleuthkit/autopsy/events/AutopsyEventPublisher.java
@@ -40,7 +40,7 @@ public final class AutopsyEventPublisher {
      * Composed of thread-safe objects.
      */
     private static final Logger logger = Logger.getLogger(AutopsyEventPublisher.class.getName());
-    private static final int MAX_REMOTE_EVENT_PUBLISH_TRIES = 3;
+    private static final int MAX_REMOTE_EVENT_PUBLISH_TRIES = 1;
     private final LocalEventPublisher localPublisher;
     private RemoteEventPublisher remotePublisher;
     private String currentChannelName;


### PR DESCRIPTION
Also, added catch-all exception firewall to all tasks scheduled by a ScheduledThreadPoolExecutor