### PR TITLE
Tl replace last obj with .properties file based book keeping

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/timeline/Bundle.properties
+++ b/Core/src/org/sleuthkit/autopsy/timeline/Bundle.properties
@@ -1,4 +1,4 @@
-CTL_MakeTimeline="Timeline"
+CTL_MakeTimeline=Timeline
 CTL_TimeLineTopComponentAction=TimeLineTopComponent
 CTL_TimeLineTopComponent=Timeline Window
 HINT_TimeLineTopComponent=This is a Timeline window
@@ -24,7 +24,5 @@ TimelinePanel.jButton7.text=3d
 TimelinePanel.jButton2.text=1m
 TimelinePanel.jButton3.text=3m
 TimelinePanel.jButton4.text=2w
-OpenTimelineAction.title=Timeline
-OpenTimeLineAction.msgdlg.text=Could not create timeline, there are no data sources.
 ProgressWindow.progressHeader.text=\ 
 

--- a/Core/src/org/sleuthkit/autopsy/timeline/OpenTimelineAction.java
+++ b/Core/src/org/sleuthkit/autopsy/timeline/OpenTimelineAction.java
@@ -18,6 +18,7 @@
  */
 package org.sleuthkit.autopsy.timeline;
 
+import java.io.IOException;
 import java.util.logging.Level;
 import javax.swing.JOptionPane;
 import org.openide.awt.ActionID;
@@ -31,6 +32,7 @@ import org.openide.windows.WindowManager;
 import org.sleuthkit.autopsy.casemodule.Case;
 import org.sleuthkit.autopsy.core.Installer;
 import org.sleuthkit.autopsy.coreutils.Logger;
+import org.sleuthkit.autopsy.coreutils.MessageNotifyUtil;
 import org.sleuthkit.autopsy.coreutils.ThreadConfined;
 
 @ActionID(category = "Tools", id = "org.sleuthkit.autopsy.timeline.Timeline")
@@ -74,14 +76,18 @@ public class OpenTimelineAction extends CallableSystemAction {
             return;
         }
 
-        if (timeLineController == null) {
-            timeLineController = new TimeLineController(currentCase);
-        } else if (timeLineController.getAutopsyCase() != currentCase) {
-            timeLineController.closeTimeLine();
-            timeLineController = new TimeLineController(currentCase);
+        try {
+            if (timeLineController == null) {
+                timeLineController = new TimeLineController(currentCase);
+            } else if (timeLineController.getAutopsyCase() != currentCase) {
+                timeLineController.closeTimeLine();
+                timeLineController = new TimeLineController(currentCase);
+            }
+            timeLineController.openTimeLine();
+        } catch (IOException iOException) {
+            MessageNotifyUtil.Notify.error("Timeline", "Failed to initialize timeline settings.");
+            LOGGER.log(Level.SEVERE, "Failed to initialize per case timeline settings.");
         }
-
-        timeLineController.openTimeLine();
     }
 
     @Override

--- a/Core/src/org/sleuthkit/autopsy/timeline/OpenTimelineAction.java
+++ b/Core/src/org/sleuthkit/autopsy/timeline/OpenTimelineAction.java
@@ -80,7 +80,7 @@ public class OpenTimelineAction extends CallableSystemAction {
             if (timeLineController == null) {
                 timeLineController = new TimeLineController(currentCase);
             } else if (timeLineController.getAutopsyCase() != currentCase) {
-                timeLineController.closeTimeLine();
+                timeLineController.shutDownTimeLine();
                 timeLineController = new TimeLineController(currentCase);
             }
             timeLineController.openTimeLine();

--- a/Core/src/org/sleuthkit/autopsy/timeline/PerCaseTimelineProperties.java
+++ b/Core/src/org/sleuthkit/autopsy/timeline/PerCaseTimelineProperties.java
@@ -1,0 +1,144 @@
+/*
+ * Autopsy Forensic Browser
+ *
+ * Copyright 2016 Basis Technology Corp.
+ * Contact: carrier <at> sleuthkit <dot> org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sleuthkit.autopsy.timeline;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Properties;
+import org.apache.commons.lang3.StringUtils;
+import org.sleuthkit.autopsy.casemodule.Case;
+
+/**
+ * Provides access to per-case timeline properties/settings.
+ */
+class PerCaseTimelineProperties {
+
+    public static final String STALE_KEY = "stale"; //NON-NLS
+    public static final String WAS_INGEST_RUNNING_KEY = "was_ingest_running"; // NON-NLS
+
+    private final Case theCase;
+    private final Path propertiesPath;
+
+    PerCaseTimelineProperties(Case c) {
+        this.theCase = c;
+        propertiesPath = Paths.get(theCase.getModuleDirectory(), "Timeline", "timeline.properties"); //NON-NLS
+    }
+
+    public synchronized boolean isDbStale() throws IOException {
+        String stale = getConfigSetting(STALE_KEY);
+        return StringUtils.isBlank(stale) ? true : Boolean.valueOf(stale);
+    }
+
+    public synchronized void setDbStale(Boolean stale) throws IOException {
+        setConfigSetting(STALE_KEY, stale.toString());
+    }
+
+    public synchronized boolean wasIngestRunning() throws IOException {
+        String stale = getConfigSetting(WAS_INGEST_RUNNING_KEY);
+        return StringUtils.isBlank(stale) ? true : Boolean.valueOf(stale);
+    }
+
+    public synchronized void setIngestRunning(Boolean stale) throws IOException {
+        setConfigSetting(WAS_INGEST_RUNNING_KEY, stale.toString());
+    }
+
+    /**
+     * Makes a new config file of the specified name. Do not include the
+     * extension.
+     *
+     * @param moduleName - The name of the config file to make
+     *
+     * @return True if successfully created, false if already exists or an error
+     *         is thrown.
+     */
+    private synchronized Path getPropertiesPath() throws IOException {
+
+        if (!Files.exists(propertiesPath)) {
+            Path parent = propertiesPath.getParent();
+            Files.createDirectories(parent);
+            Files.createFile(propertiesPath);
+        }
+        return propertiesPath;
+    }
+
+    /**
+     * Returns the given properties file's setting as specific by settingName.
+     *
+     * @param moduleName  - The name of the config file to read from.
+     * @param settingName - The setting name to retrieve.
+     *
+     * @return - the value associated with the setting.
+     *
+     * @throws IOException
+     */
+    private synchronized String getConfigSetting(String settingName) throws IOException {
+        return getProperties().getProperty(settingName);
+    }
+
+    /**
+     * Sets the given properties file to the given settings.
+     *
+     * @param moduleName  - The name of the module to be written to.
+     * @param settingName - The name of the setting to be modified.
+     * @param settingVal  - the value to set the setting to.
+     */
+    private synchronized void setConfigSetting(String settingName, String settingVal) throws IOException {
+        Path propertiesFile = getPropertiesPath();
+        Properties props = getProperties(propertiesFile);
+        props.setProperty(settingName, settingVal);
+
+        try (OutputStream fos = Files.newOutputStream(propertiesFile)) {
+            props.store(fos, ""); //NON-NLS
+        }
+    }
+
+    /**
+     * Returns the properties as specified by moduleName.
+     *
+     * @param moduleName
+     * @param propertiesFile the value of propertiesFile
+     *
+     * @throws IOException
+     * @return the java.util.Properties
+     */
+    private synchronized Properties getProperties() throws IOException {
+        return getProperties(getPropertiesPath());
+    }
+
+    /**
+     * Returns the properties as specified by moduleName.
+     *
+     * @param moduleName
+     *
+     * @return Properties file as specified by moduleName.
+     *
+     * @throws IOException
+     */
+    private synchronized Properties getProperties(final Path propertiesFile) throws IOException {
+        try (InputStream inputStream = Files.newInputStream(propertiesFile)) {
+            Properties props = new Properties();
+            props.load(inputStream);
+            return props;
+        }
+    }
+}

--- a/Core/src/org/sleuthkit/autopsy/timeline/TimeLineController.java
+++ b/Core/src/org/sleuthkit/autopsy/timeline/TimeLineController.java
@@ -250,7 +250,7 @@ public class TimeLineController {
     public TimeLineController(Case autoCase) throws IOException {
         this.autoCase = autoCase;
         this.perCaseTimelineProperties = new PerCaseTimelineProperties(autoCase);
-        eventsDBStale.set(perCaseTimelineProperties.isDbStale());
+        eventsDBStale.set(perCaseTimelineProperties.isDBStale());
         eventsRepository = new EventsRepository(autoCase, currentParams.getReadOnlyProperty());
         /*
          * as the history manager's current state changes, modify the tags

--- a/Core/src/org/sleuthkit/autopsy/timeline/ui/StatusBar.java
+++ b/Core/src/org/sleuthkit/autopsy/timeline/ui/StatusBar.java
@@ -74,8 +74,8 @@ public class StatusBar extends ToolBar {
         taskLabel.setVisible(false);
         HBox.setHgrow(spacer, Priority.ALWAYS);
 
-        refreshLabel.visibleProperty().bind(this.controller.getNewEventsFlag());
-        refreshLabel.managedProperty().bind(this.controller.getNewEventsFlag());
+        refreshLabel.visibleProperty().bind(this.controller.eventsDBStaleProperty());
+        refreshLabel.managedProperty().bind(this.controller.eventsDBStaleProperty());
         taskLabel.textProperty().bind(this.controller.taskTitleProperty());
         messageLabel.textProperty().bind(this.controller.taskMessageProperty());
         progressBar.progressProperty().bind(this.controller.taskProgressProperty());
@@ -83,6 +83,5 @@ public class StatusBar extends ToolBar {
 
         statusLabel.textProperty().bind(this.controller.getStatusProperty());
         statusLabel.visibleProperty().bind(statusLabel.textProperty().isNotEmpty());
-
     }
 }

--- a/Core/src/org/sleuthkit/autopsy/timeline/ui/VisualizationPanel.java
+++ b/Core/src/org/sleuthkit/autopsy/timeline/ui/VisualizationPanel.java
@@ -347,9 +347,9 @@ final public class VisualizationPanel extends BorderPane {
         refreshTimeUI(); //populate the viz
 
         //this should use an event(EventBus) , not this weird observable pattern
-        controller.getNeedsHistogramRebuild().addListener((observable, oldValue, newValue) -> {
-            if (newValue) {
-                refreshHistorgram();
+        controller.eventsDBStaleProperty().addListener(staleProperty -> {
+            if (controller.isEventsDBStale()) {
+                Platform.runLater(VisualizationPanel.this::refreshHistorgram);
             }
         });
         refreshHistorgram();
@@ -569,7 +569,7 @@ final public class VisualizationPanel extends BorderPane {
 
             titledPane.setText(Bundle.NoEventsDialog_titledPane_text());
             noEventsDialogLabel.setText(NbBundle.getMessage(NoEventsDialog.class, "VisualizationPanel.noEventsDialogLabel.text")); // NON-NLS
-         
+
             dismissButton.setOnAction(actionEvent -> closeCallback.run());
 
             ActionUtils.configureButton(new ZoomToEvents(controller), zoomButton);


### PR DESCRIPTION
no longer used deprecated SleuthKitCase.getLastObjectID() to determine if the events db is up to date.
instead respond to events by maintain a properties file with the staleness of the events db