### PR TITLE
use alias in sql query to avoid ambiguity about column name

### DIFF
--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/grouping/DrawableGroup.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/grouping/DrawableGroup.java
@@ -34,7 +34,6 @@ import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import org.sleuthkit.autopsy.coreutils.Logger;
 import org.sleuthkit.autopsy.imagegallery.ImageGalleryController;
-import org.sleuthkit.autopsy.imagegallery.datamodel.Category;
 import org.sleuthkit.autopsy.imagegallery.datamodel.CategoryManager;
 import org.sleuthkit.autopsy.imagegallery.datamodel.DrawableAttribute;
 
@@ -142,7 +141,7 @@ public class DrawableGroup implements Comparable<DrawableGroup> {
     public final synchronized long getUncategorizedCount() {
         if (uncatCount.get() < 0) {
             try {
-                uncatCount.set(ImageGalleryController.getDefault().getDatabase().getCategoryCount(Category.ZERO, fileIDs));
+                uncatCount.set(ImageGalleryController.getDefault().getDatabase().getUncategorizedCount(fileIDs));
 
             } catch (IllegalStateException | NullPointerException ex) {
                 LOGGER.log(Level.WARNING, "could not access case during getFilesWithHashSetHitsCount()"); //NON-NLS


### PR DESCRIPTION
also renamed method to conform to its only existing invocation.