### PR TITLE
1862 Fixed a bug where ingest module startup errors were ingnored

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/ingest/IngestManager.java
+++ b/Core/src/org/sleuthkit/autopsy/ingest/IngestManager.java
@@ -594,6 +594,8 @@ public class IngestManager {
                         JOptionPane.showMessageDialog(null, message, Bundle.IngestManager_startupErr_dlgTitle(), JOptionPane.ERROR_MESSAGE);
                     });
                 }
+                // abort ingest
+                return new IngestJobStartResult(null, new IngestManagerException("Errors occurred while starting ingest"), errors);
             }
         }
         return new IngestJobStartResult(job, null, errors);


### PR DESCRIPTION
Ingest job was correctly getting cancelled by ingest manager but a valid IngestJobStartResult was being returned creating a major confusion and an ingest job that runs forever.