### PR TITLE
1878 Fixed a bug where indexed text content viewer erroneously reported "no keyword hits"

### DIFF
--- a/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/Bundle.properties
+++ b/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/Bundle.properties
@@ -64,7 +64,7 @@ ExtractedContentViewer.getTitle=Indexed Text
 ExtractedContentViewer.getSolrContent.knownFileMsg=<p style\=''font-style\:italic''>{0} is a known file (based on MD5 hash) and does not have text in the index.</p>
 ExtractedContentViewer.getSolrContent.noTxtYetMsg=<p style\=''font-style\:italic''>{0} does not have text in the index.<br/>It may have no text, not been analyzed yet, or keyword search was not enabled during ingest.</p>
 ExtractedContentViewer.getSolrContent.txtBodyItal=<span style\=''font-style\:italic''>{0}</span>
-HighlightedMatchesSource.getMarkup.noMatchMsg=<html><pre><span style\\\\\='background\\\\\:yellow'>There were no keyword hits on this page. <br />Keyword could have been in file name. <br />Advance to another page for hits or choose Extracted Text to view original text..</span></pre></html>
+HighlightedMatchesSource.getMarkup.noMatchMsg=<html><pre><span style\\\\\='background\\\\\:yellow'>There were no keyword hits on this page. <br />Keyword could have been in file name. <br />Advance to another page for hits or to view original text choose File Text <br />in the drop down menu to the right..</span></pre></html>
 HighlightedMatchesSource.getMarkup.queryFailedMsg=<html><pre><span style\\\\\='background\\\\\:yellow'>Failed to retrieve keyword hit results. <br />Confirm that Autopsy can connect to the Solr server. <br /></span></pre></html>
 HighlightedMatchesSource.toString=Search Results
 Installer.reportPortError=Indexing server port {0} is not available.  Check if your security software does not block {1} and consider changing {2} in {3} property file in the application user folder. Then try rebooting your system if another process was causing the conflict.

--- a/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/HighlightedText.java
+++ b/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/HighlightedText.java
@@ -298,26 +298,28 @@ class HighlightedText implements IndexedText, TextMarkupLookup {
 
         String highLightField = null;
 
-        String highlightQuery = keywordHitQuery;
+        //String highlightQuery = keywordHitQuery;
 
         if (isRegex) {
             highLightField = LuceneQuery.HIGHLIGHT_FIELD_REGEX;
             //escape special lucene chars if not already escaped (if not a compound query)
             //TODO a better way to mark it a compound highlight query
-            final String findSubstr = LuceneQuery.HIGHLIGHT_FIELD_REGEX + ":";
-            if (!highlightQuery.contains(findSubstr)) {
-                highlightQuery = KeywordSearchUtil.escapeLuceneQuery(highlightQuery);
-            }
+            
+            // ELDEBUG:
+            //final String findSubstr = LuceneQuery.HIGHLIGHT_FIELD_REGEX + ":";
+            //if (!highlightQuery.contains(findSubstr)) {
+            //    highlightQuery = KeywordSearchUtil.escapeLuceneQuery(highlightQuery);
+            //}
         } else {
             highLightField = LuceneQuery.HIGHLIGHT_FIELD_LITERAL;
             //escape special lucene chars always for literal queries query
-            highlightQuery = KeywordSearchUtil.escapeLuceneQuery(highlightQuery);
+            //highlightQuery = KeywordSearchUtil.escapeLuceneQuery(highlightQuery);
         }
 
         SolrQuery q = new SolrQuery();
         q.setShowDebugInfo(DEBUG); //debug
 
-        String queryStr = null;
+        /*String queryStr = null;
 
         if (isRegex) {
             StringBuilder sb = new StringBuilder();
@@ -334,9 +336,10 @@ class HighlightedText implements IndexedText, TextMarkupLookup {
             //use default field, simplifies query
             //always force grouping/quotes
             queryStr = KeywordSearchUtil.quoteQuery(highlightQuery);
-        }
+        }*/
 
-        q.setQuery(queryStr);
+        //q.setQuery(queryStr);
+        q.setQuery(keywordHitQuery);
 
         String contentIdStr = Long.toString(this.objectId);
         if (hasChunks) {

--- a/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/HighlightedText.java
+++ b/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/HighlightedText.java
@@ -298,47 +298,16 @@ class HighlightedText implements IndexedText, TextMarkupLookup {
 
         String highLightField = null;
 
-        //String highlightQuery = keywordHitQuery;
-
         if (isRegex) {
             highLightField = LuceneQuery.HIGHLIGHT_FIELD_REGEX;
-            //escape special lucene chars if not already escaped (if not a compound query)
-            //TODO a better way to mark it a compound highlight query
-            
-            // ELDEBUG:
-            //final String findSubstr = LuceneQuery.HIGHLIGHT_FIELD_REGEX + ":";
-            //if (!highlightQuery.contains(findSubstr)) {
-            //    highlightQuery = KeywordSearchUtil.escapeLuceneQuery(highlightQuery);
-            //}
         } else {
             highLightField = LuceneQuery.HIGHLIGHT_FIELD_LITERAL;
-            //escape special lucene chars always for literal queries query
-            //highlightQuery = KeywordSearchUtil.escapeLuceneQuery(highlightQuery);
         }
 
         SolrQuery q = new SolrQuery();
         q.setShowDebugInfo(DEBUG); //debug
 
-        /*String queryStr = null;
-
-        if (isRegex) {
-            StringBuilder sb = new StringBuilder();
-            sb.append(highLightField).append(":");
-            if (group) {
-                sb.append("\"");
-            }
-            sb.append(highlightQuery);
-            if (group) {
-                sb.append("\"");
-            }
-            queryStr = sb.toString();
-        } else {
-            //use default field, simplifies query
-            //always force grouping/quotes
-            queryStr = KeywordSearchUtil.quoteQuery(highlightQuery);
-        }*/
-
-        //q.setQuery(queryStr);
+        // input query has already been escaped
         q.setQuery(keywordHitQuery);
 
         String contentIdStr = Long.toString(this.objectId);

--- a/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/HighlightedText.java
+++ b/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/HighlightedText.java
@@ -339,7 +339,6 @@ class HighlightedText implements IndexedText, TextMarkupLookup {
             Map<String, List<String>> responseHighlightID = responseHighlight.get(contentIdStr);
             if (responseHighlightID == null) {
                 return NbBundle.getMessage(this.getClass(), "HighlightedMatchesSource.getMarkup.noMatchMsg");
-
             }
             List<String> contentHighlights = responseHighlightID.get(highLightField);
             if (contentHighlights == null) {
@@ -352,6 +351,7 @@ class HighlightedText implements IndexedText, TextMarkupLookup {
                 return "<html><pre>" + highlightedContent + "</pre></html>"; //NON-NLS
             }
         } catch (Exception ex) {
+            logger.log(Level.WARNING, "Error executing Solr highlighting query: " + keywordHitQuery, ex); //NON-NLS
             return NbBundle.getMessage(this.getClass(), "HighlightedMatchesSource.getMarkup.queryFailedMsg");
         }
     }

--- a/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/HighlightedText.java
+++ b/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/HighlightedText.java
@@ -379,7 +379,7 @@ class HighlightedText implements IndexedText, TextMarkupLookup {
 
                 return "<html><pre>" + highlightedContent + "</pre></html>"; //NON-NLS
             }
-        } catch (NoOpenCoreException | KeywordSearchModuleException ex) {
+        } catch (Exception ex) {
             return NbBundle.getMessage(this.getClass(), "HighlightedMatchesSource.getMarkup.queryFailedMsg");
         }
     }

--- a/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/HighlightedText.java
+++ b/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/HighlightedText.java
@@ -307,7 +307,7 @@ class HighlightedText implements IndexedText, TextMarkupLookup {
         SolrQuery q = new SolrQuery();
         q.setShowDebugInfo(DEBUG); //debug
 
-        // input query has already been escaped
+        // input query has already been properly constructed and escaped
         q.setQuery(keywordHitQuery);
 
         String contentIdStr = Long.toString(this.objectId);

--- a/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/KeywordSearchResultFactory.java
+++ b/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/KeywordSearchResultFactory.java
@@ -260,14 +260,15 @@ class KeywordSearchResultFactory extends ChildFactory<KeyValueQueryContent> {
                 //simple case, no need to process subqueries and do special escaping
                 Keyword term = queryResults.getKeywords().iterator().next();
                 //highlightQuery.append(term.toString());
-                highlightQuery.append(LuceneQuery.HIGHLIGHT_FIELD_REGEX).append(":").append(KeywordSearchUtil.escapeLuceneQuery(term.toString()));
+                //highlightQuery.append(LuceneQuery.HIGHLIGHT_FIELD_REGEX).append(":").append(KeywordSearchUtil.escapeLuceneQuery(term.toString()));
+                highlightQuery.append(LuceneQuery.HIGHLIGHT_FIELD_REGEX).append(":").append(KeywordSearchUtil.escapeLuceneQuery(term.getQuery()));
             } else {
                 //find terms for this content hit
-                List<String> hitTerms = new ArrayList<>();
+                List<Keyword> hitTerms = new ArrayList<>();
                 for (Keyword keyword : queryResults.getKeywords()) {
                     for (KeywordHit hit : queryResults.getResults(keyword)) {
                         if (hit.getContent().equals(content)) {
-                            hitTerms.add(keyword.toString());
+                            hitTerms.add(keyword);
                             break; //go to next term
                         }
                     }
@@ -275,13 +276,13 @@ class KeywordSearchResultFactory extends ChildFactory<KeyValueQueryContent> {
 
                 final int lastTerm = hitTerms.size() - 1;
                 int curTerm = 0;
-                for (String term : hitTerms) {
+                for (Keyword term : hitTerms) {
                     //escape subqueries, they shouldn't be escaped again later
                     //StringBuilder currentKeywordQuery = new StringBuilder();
                     //currentKeywordQuery.append(LuceneQuery.HIGHLIGHT_FIELD_REGEX).append(":").append(KeywordSearchUtil.escapeLuceneQuery(term));                    
                     //highlightQuery.append(KeywordSearchUtil.quoteQuery(currentKeywordQuery.toString()));
                     
-                    highlightQuery.append(LuceneQuery.HIGHLIGHT_FIELD_REGEX).append(":").append(KeywordSearchUtil.escapeLuceneQuery(term));    
+                    highlightQuery.append(LuceneQuery.HIGHLIGHT_FIELD_REGEX).append(":").append("\"").append(KeywordSearchUtil.escapeLuceneQuery(term.getQuery())).append("\"");    
                     
                     /*final String termS = KeywordSearchUtil.escapeLuceneQuery(term);
                     highlightQuery.append("\"");

--- a/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/KeywordSearchResultFactory.java
+++ b/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/KeywordSearchResultFactory.java
@@ -247,7 +247,6 @@ class KeywordSearchResultFactory extends ChildFactory<KeyValueQueryContent> {
      * @return
      */
     private String getHighlightQuery(KeywordSearchQuery query, boolean literal_query, QueryResults queryResults, Content content) {
-        //String highlightQueryEscaped;
         StringBuilder highlightQuery = new StringBuilder();
         if (literal_query) {
             //literal, treat as non-regex, non-term component query
@@ -255,12 +254,9 @@ class KeywordSearchResultFactory extends ChildFactory<KeyValueQueryContent> {
         } else {
             //construct a Solr query using aggregated terms to get highlighting
             //the query is executed later on demand
-
             if (queryResults.getKeywords().size() == 1) {
                 //simple case, no need to process subqueries and do special escaping
                 Keyword term = queryResults.getKeywords().iterator().next();
-                //highlightQuery.append(term.toString());
-                //highlightQuery.append(LuceneQuery.HIGHLIGHT_FIELD_REGEX).append(":").append(KeywordSearchUtil.escapeLuceneQuery(term.toString()));
                 highlightQuery.append(LuceneQuery.HIGHLIGHT_FIELD_REGEX).append(":").append(KeywordSearchUtil.escapeLuceneQuery(term.getQuery()));
             } else {
                 //find terms for this content hit
@@ -277,33 +273,15 @@ class KeywordSearchResultFactory extends ChildFactory<KeyValueQueryContent> {
                 final int lastTerm = hitTerms.size() - 1;
                 int curTerm = 0;
                 for (Keyword term : hitTerms) {
-                    //escape subqueries, they shouldn't be escaped again later
-                    //StringBuilder currentKeywordQuery = new StringBuilder();
-                    //currentKeywordQuery.append(LuceneQuery.HIGHLIGHT_FIELD_REGEX).append(":").append(KeywordSearchUtil.escapeLuceneQuery(term));                    
-                    //highlightQuery.append(KeywordSearchUtil.quoteQuery(currentKeywordQuery.toString()));
-                    
+                    //escape subqueries, MAKE SURE they are not escaped again later
                     highlightQuery.append(LuceneQuery.HIGHLIGHT_FIELD_REGEX).append(":").append("\"").append(KeywordSearchUtil.escapeLuceneQuery(term.getQuery())).append("\"");    
-                    
-                    /*final String termS = KeywordSearchUtil.escapeLuceneQuery(term);
-                    highlightQuery.append("\"");
-                    highlightQuery.append(termS);
-                    highlightQuery.append("\"");*/
-                    
-                    //highlightQuery.append(term);    // ELDEBUG
                     if (lastTerm != curTerm) {
                         highlightQuery.append(" "); //acts as OR ||
-                        //force HIGHLIGHT_FIELD_REGEX index and stored content
-                        //in each term after first. First term taken care by HighlightedMatchesSource
-                       
-                        //highlightQuery.append(LuceneQuery.HIGHLIGHT_FIELD_REGEX).append(":");
                     }
 
                     ++curTerm;
                 }
             }
-            //String highlightQueryEscaped = KeywordSearchUtil.escapeLuceneQuery(highlightQuery.toString());
-            
-            //highlightQueryEscaped = highlightQuery.toString();
         }
 
         return highlightQuery.toString();

--- a/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/KeywordSearchResultFactory.java
+++ b/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/KeywordSearchResultFactory.java
@@ -276,10 +276,11 @@ class KeywordSearchResultFactory extends ChildFactory<KeyValueQueryContent> {
                 int curTerm = 0;
                 for (String term : hitTerms) {
                     //escape subqueries, they shouldn't be escaped again later
-                    final String termS = KeywordSearchUtil.escapeLuceneQuery(term);
+                    /*final String termS = KeywordSearchUtil.escapeLuceneQuery(term);
                     highlightQuery.append("\"");
                     highlightQuery.append(termS);
-                    highlightQuery.append("\"");
+                    highlightQuery.append("\"");*/
+                    highlightQuery.append(term);    // ELDEBUG
                     if (lastTerm != curTerm) {
                         highlightQuery.append(" "); //acts as OR ||
                         //force HIGHLIGHT_FIELD_REGEX index and stored content

--- a/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/KeywordSearchResultFactory.java
+++ b/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/KeywordSearchResultFactory.java
@@ -250,14 +250,14 @@ class KeywordSearchResultFactory extends ChildFactory<KeyValueQueryContent> {
         StringBuilder highlightQuery = new StringBuilder();
         if (literal_query) {
             //literal, treat as non-regex, non-term component query
-            highlightQuery.append(LuceneQuery.HIGHLIGHT_FIELD_LITERAL).append(":").append(KeywordSearchUtil.escapeLuceneQuery(query.getQueryString()));
+            highlightQuery.append(LuceneQuery.HIGHLIGHT_FIELD_LITERAL).append(":").append("\"").append(KeywordSearchUtil.escapeLuceneQuery(query.getQueryString())).append("\"");
         } else {
             //construct a Solr query using aggregated terms to get highlighting
             //the query is executed later on demand
             if (queryResults.getKeywords().size() == 1) {
                 //simple case, no need to process subqueries and do special escaping
                 Keyword term = queryResults.getKeywords().iterator().next();
-                highlightQuery.append(LuceneQuery.HIGHLIGHT_FIELD_REGEX).append(":").append(KeywordSearchUtil.escapeLuceneQuery(term.getQuery()));
+                highlightQuery.append(LuceneQuery.HIGHLIGHT_FIELD_REGEX).append(":").append("\"").append(KeywordSearchUtil.escapeLuceneQuery(term.getQuery())).append("\"");
             } else {
                 //find terms for this content hit
                 List<Keyword> hitTerms = new ArrayList<>();


### PR DESCRIPTION
Actually ad-hoc substring match and regex KWS result highlighting has been broken since at least version 2.0.0.5 (November 2014). "Indexed Text" content viewer would incorrectly state that no KWS hits were found in the selected KWS result.

There were several errors in the code. There were several code paths were Solr highlighting query was getting escaped twice. In addition, all but the simplest highlighting queries were constructed and/or escaped incorrectly. The logic was also spread across several classes and different event handlers. 