### PR TITLE
Updated use of PropertyChangeSupport in LocalDiskPanel and the panels…

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/casemodule/LocalDiskPanel.java
+++ b/Core/src/org/sleuthkit/autopsy/casemodule/LocalDiskPanel.java
@@ -22,8 +22,6 @@ import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Font;
-import java.beans.PropertyChangeListener;
-import java.beans.PropertyChangeSupport;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
@@ -54,15 +52,9 @@ import org.sleuthkit.autopsy.coreutils.PlatformUtil;
 final class LocalDiskPanel extends JPanel {
 
     private static final Logger logger = Logger.getLogger(LocalDiskPanel.class.getName());
-
     private static LocalDiskPanel instance;
-
-    private PropertyChangeSupport pcs = null;
-
     private List<LocalDisk> disks;
-
     private LocalDiskModel model;
-
     private boolean enableNext = false;
 
     /**
@@ -252,24 +244,6 @@ final class LocalDiskPanel extends JPanel {
 
     }
 
-    @Override
-    public synchronized void addPropertyChangeListener(PropertyChangeListener pcl) {
-        super.addPropertyChangeListener(pcl);
-
-        if (pcs == null) {
-            pcs = new PropertyChangeSupport(this);
-        }
-
-        pcs.addPropertyChangeListener(pcl);
-    }
-
-    @Override
-    public void removePropertyChangeListener(PropertyChangeListener pcl) {
-        super.removePropertyChangeListener(pcl);
-
-        pcs.removePropertyChangeListener(pcl);
-    }
-
     /**
      * Creates the drop down list for the time zones and then makes the local
      * machine time zone to be selected.
@@ -353,7 +327,7 @@ final class LocalDiskPanel extends JPanel {
                 enableNext = true;
 
                 try {
-                    pcs.firePropertyChange(DataSourceProcessor.DSP_PANEL_EVENT.UPDATE_UI.toString(), false, true);
+                    firePropertyChange(DataSourceProcessor.DSP_PANEL_EVENT.UPDATE_UI.toString(), false, true);
                 } catch (Exception e) {
                     logger.log(Level.SEVERE, "LocalDiskPanel listener threw exception", e); //NON-NLS
                     MessageNotifyUtil.Notify.show(NbBundle.getMessage(this.getClass(), "LocalDiskPanel.moduleErr"),

--- a/Core/src/org/sleuthkit/autopsy/corecomponents/AutopsyOptionsPanel.java
+++ b/Core/src/org/sleuthkit/autopsy/corecomponents/AutopsyOptionsPanel.java
@@ -18,8 +18,6 @@
  */
 package org.sleuthkit.autopsy.corecomponents;
 
-import java.beans.PropertyChangeListener;
-import java.beans.PropertyChangeSupport;
 import java.text.NumberFormat;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.JFormattedTextField;
@@ -33,8 +31,6 @@ import org.sleuthkit.autopsy.core.UserPreferences;
  * Options panel that allow users to set application preferences.
  */
 final class AutopsyOptionsPanel extends javax.swing.JPanel {
-
-    private final PropertyChangeSupport pcs = new PropertyChangeSupport(this);
 
     AutopsyOptionsPanel() {
         initComponents();
@@ -82,17 +78,17 @@ final class AutopsyOptionsPanel extends javax.swing.JPanel {
 
             @Override
             public void insertUpdate(DocumentEvent e) {
-                pcs.firePropertyChange(OptionsPanelController.PROP_CHANGED, null, null);
+                firePropertyChange(OptionsPanelController.PROP_CHANGED, null, null);
             }
 
             @Override
             public void removeUpdate(DocumentEvent e) {
-                pcs.firePropertyChange(OptionsPanelController.PROP_CHANGED, null, null);
+                firePropertyChange(OptionsPanelController.PROP_CHANGED, null, null);
             }
 
             @Override
             public void changedUpdate(DocumentEvent e) {
-                pcs.firePropertyChange(OptionsPanelController.PROP_CHANGED, null, null);
+                firePropertyChange(OptionsPanelController.PROP_CHANGED, null, null);
             }
         };
         this.jFormattedTextFieldProcTimeOutHrs.getDocument().addDocumentListener(docListener);
@@ -138,17 +134,7 @@ final class AutopsyOptionsPanel extends javax.swing.JPanel {
             UserPreferences.setProcessTimeOutHrs((int) timeOutHrs);
         }
     }
-
-    @Override
-    public void addPropertyChangeListener(PropertyChangeListener l) {
-        pcs.addPropertyChangeListener(l);
-    }
-
-    @Override
-    public void removePropertyChangeListener(PropertyChangeListener l) {
-        pcs.removePropertyChangeListener(l);
-    }
-
+    
     boolean valid() {
         return true;
     }
@@ -361,39 +347,39 @@ final class AutopsyOptionsPanel extends javax.swing.JPanel {
 
     private void jCheckBoxEnableProcTimeoutActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jCheckBoxEnableProcTimeoutActionPerformed
         jFormattedTextFieldProcTimeOutHrs.setEditable(jCheckBoxEnableProcTimeout.isSelected());
-        pcs.firePropertyChange(OptionsPanelController.PROP_CHANGED, null, null);
+        firePropertyChange(OptionsPanelController.PROP_CHANGED, null, null);
     }//GEN-LAST:event_jCheckBoxEnableProcTimeoutActionPerformed
 
     private void useBestViewerRBActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_useBestViewerRBActionPerformed
-        pcs.firePropertyChange(OptionsPanelController.PROP_CHANGED, null, null);
+        firePropertyChange(OptionsPanelController.PROP_CHANGED, null, null);
     }//GEN-LAST:event_useBestViewerRBActionPerformed
 
     private void keepCurrentViewerRBActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_keepCurrentViewerRBActionPerformed
-        pcs.firePropertyChange(OptionsPanelController.PROP_CHANGED, null, null);
+        firePropertyChange(OptionsPanelController.PROP_CHANGED, null, null);
     }//GEN-LAST:event_keepCurrentViewerRBActionPerformed
 
     private void dataSourcesHideKnownCBActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_dataSourcesHideKnownCBActionPerformed
-        pcs.firePropertyChange(OptionsPanelController.PROP_CHANGED, null, null);
+        firePropertyChange(OptionsPanelController.PROP_CHANGED, null, null);
     }//GEN-LAST:event_dataSourcesHideKnownCBActionPerformed
 
     private void viewsHideKnownCBActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_viewsHideKnownCBActionPerformed
-        pcs.firePropertyChange(OptionsPanelController.PROP_CHANGED, null, null);
+        firePropertyChange(OptionsPanelController.PROP_CHANGED, null, null);
     }//GEN-LAST:event_viewsHideKnownCBActionPerformed
 
     private void useLocalTimeRBActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_useLocalTimeRBActionPerformed
-        pcs.firePropertyChange(OptionsPanelController.PROP_CHANGED, null, null);
+        firePropertyChange(OptionsPanelController.PROP_CHANGED, null, null);
     }//GEN-LAST:event_useLocalTimeRBActionPerformed
 
     private void useGMTTimeRBActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_useGMTTimeRBActionPerformed
-        pcs.firePropertyChange(OptionsPanelController.PROP_CHANGED, null, null);
+        firePropertyChange(OptionsPanelController.PROP_CHANGED, null, null);
     }//GEN-LAST:event_useGMTTimeRBActionPerformed
 
     private void numberOfFileIngestThreadsComboBoxActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_numberOfFileIngestThreadsComboBoxActionPerformed
-        pcs.firePropertyChange(OptionsPanelController.PROP_CHANGED, null, null);
+        firePropertyChange(OptionsPanelController.PROP_CHANGED, null, null);
     }//GEN-LAST:event_numberOfFileIngestThreadsComboBoxActionPerformed
 
     private void jFormattedTextFieldProcTimeOutHrsActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jFormattedTextFieldProcTimeOutHrsActionPerformed
-        pcs.firePropertyChange(OptionsPanelController.PROP_CHANGED, null, null);
+        firePropertyChange(OptionsPanelController.PROP_CHANGED, null, null);
     }//GEN-LAST:event_jFormattedTextFieldProcTimeOutHrsActionPerformed
 
     // Variables declaration - do not modify//GEN-BEGIN:variables

--- a/Core/src/org/sleuthkit/autopsy/corecomponents/DataResultPanel.java
+++ b/Core/src/org/sleuthkit/autopsy/corecomponents/DataResultPanel.java
@@ -329,11 +329,6 @@ public class DataResultPanel extends javax.swing.JPanel implements DataResult, C
      * listeners.
      */
     void close() {
-        // try to remove any references to this class
-        PropertyChangeListener[] pcls = getPropertyChangeListeners();
-        for (PropertyChangeListener pcl : pcls) {
-            removePropertyChangeListener(pcl);
-        }
 
         if (null != explorerManager && null != emNodeSelectionListener) {
             explorerManager.removePropertyChangeListener(emNodeSelectionListener);

--- a/Core/src/org/sleuthkit/autopsy/corecomponents/DataResultPanel.java
+++ b/Core/src/org/sleuthkit/autopsy/corecomponents/DataResultPanel.java
@@ -21,10 +21,8 @@ package org.sleuthkit.autopsy.corecomponents;
 import java.awt.Cursor;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.beans.PropertyChangeSupport;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
 import javax.swing.JTabbedPane;
 import javax.swing.SwingUtilities;
 import javax.swing.event.ChangeEvent;
@@ -59,7 +57,6 @@ public class DataResultPanel extends javax.swing.JPanel implements DataResult, C
     private ExplorerManagerNodeSelectionListener emNodeSelectionListener;
     
     private Node rootNode;
-    private PropertyChangeSupport pcs;
 
     // Different DataResultsViewers
     private final List<UpdateWrapper> viewers = new ArrayList<>();
@@ -81,7 +78,6 @@ public class DataResultPanel extends javax.swing.JPanel implements DataResult, C
      */
     private DataResultPanel() {
         this.isMain = true;
-        pcs = new PropertyChangeSupport(this);
         initComponents();
 
         setName(title);
@@ -334,9 +330,9 @@ public class DataResultPanel extends javax.swing.JPanel implements DataResult, C
      */
     void close() {
         // try to remove any references to this class
-        PropertyChangeListener[] pcl = pcs.getPropertyChangeListeners();
-        for (int i = 0; i < pcl.length; i++) {
-            pcs.removePropertyChangeListener(pcl[i]);
+        PropertyChangeListener[] pcls = getPropertyChangeListeners();
+        for (PropertyChangeListener pcl : pcls) {
+            removePropertyChangeListener(pcl);
         }
 
         if (null != explorerManager && null != emNodeSelectionListener) {
@@ -360,25 +356,9 @@ public class DataResultPanel extends javax.swing.JPanel implements DataResult, C
             this.matchLabel.removeAll();
             this.matchLabel = null;
             this.setLayout(null);
-            this.pcs = null;
             this.removeAll();
             this.setVisible(false);
         }
-    }
-
-    @Override
-    public synchronized void addPropertyChangeListener(PropertyChangeListener listener) {
-        if (pcs == null) {
-            logger.log(Level.WARNING, "Could not add listener to DataResultPanel, " //NON-NLS
-                    + "listener support not fully initialized yet, listener: " + listener.toString()); //NON-NLS
-        } else {
-            this.pcs.addPropertyChangeListener(listener);
-        }
-    }
-
-    @Override
-    public synchronized void removePropertyChangeListener(PropertyChangeListener listener) {
-        this.pcs.removePropertyChangeListener(listener);
     }
 
     @Override

--- a/Core/src/org/sleuthkit/autopsy/directorytree/DirectoryTreeTopComponent.java
+++ b/Core/src/org/sleuthkit/autopsy/directorytree/DirectoryTreeTopComponent.java
@@ -22,7 +22,6 @@ import java.awt.Cursor;
 import java.awt.EventQueue;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.beans.PropertyChangeSupport;
 import java.beans.PropertyVetoException;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -93,7 +92,6 @@ public final class DirectoryTreeTopComponent extends TopComponent implements Dat
     private final LinkedList<String[]> backList;
     private final LinkedList<String[]> forwardList;
     private static final String PREFERRED_ID = "DirectoryTreeTopComponent"; //NON-NLS
-    private final PropertyChangeSupport pcs;
     private static final Logger logger = Logger.getLogger(DirectoryTreeTopComponent.class.getName());
     private RootContentChildren contentChildren;
 
@@ -112,8 +110,6 @@ public final class DirectoryTreeTopComponent extends TopComponent implements Dat
 
         subscribeToChangeEvents();
         associateLookup(ExplorerUtils.createLookup(em, getActionMap()));
-
-        this.pcs = new PropertyChangeSupport(this);
 
         // set the back & forward list and also disable the back & forward button
         this.backList = new LinkedList<>();
@@ -724,16 +720,6 @@ public final class DirectoryTreeTopComponent extends TopComponent implements Dat
         forwardList.clear();
         backButton.setEnabled(false);
         forwardButton.setEnabled(false);
-    }
-
-    @Override
-    public synchronized void addPropertyChangeListener(PropertyChangeListener listener) {
-        pcs.addPropertyChangeListener(listener);
-    }
-
-    @Override
-    public synchronized void removePropertyChangeListener(PropertyChangeListener listener) {
-        pcs.removePropertyChangeListener(listener);
     }
 
     /**

--- a/Core/src/org/sleuthkit/autopsy/filesearch/DateSearchPanel.java
+++ b/Core/src/org/sleuthkit/autopsy/filesearch/DateSearchPanel.java
@@ -20,8 +20,6 @@ package org.sleuthkit.autopsy.filesearch;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.beans.PropertyChangeListener;
-import java.beans.PropertyChangeSupport;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.util.Date;
@@ -39,7 +37,6 @@ class DateSearchPanel extends javax.swing.JPanel {
 
     DateFormat dateFormat;
     List<String> timeZones;
-    private final PropertyChangeSupport pcs = new PropertyChangeSupport(this);
 
     DateSearchPanel(DateFormat dateFormat, List<String> timeZones) {
         this.dateFormat = dateFormat;
@@ -135,16 +132,6 @@ class DateSearchPanel extends javax.swing.JPanel {
         this.accessedCheckBox.setEnabled(enable);
         this.changedCheckBox.setEnabled(enable);
         this.createdCheckBox.setEnabled(enable);
-    }
-    
-    @Override
-    public void addPropertyChangeListener(PropertyChangeListener pcl) {
-        pcs.addPropertyChangeListener(pcl);
-    }
-
-    @Override
-    public void removePropertyChangeListener(PropertyChangeListener pcl) {
-        pcs.removePropertyChangeListener(pcl);
     }
 
     /**
@@ -382,23 +369,23 @@ class DateSearchPanel extends javax.swing.JPanel {
 
     private void dateCheckBoxActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_dateCheckBoxActionPerformed
         this.setComponentsEnabled();
-        pcs.firePropertyChange(FileSearchPanel.EVENT.CHECKED.toString(), null, null);
+        firePropertyChange(FileSearchPanel.EVENT.CHECKED.toString(), null, null);
     }//GEN-LAST:event_dateCheckBoxActionPerformed
 
     private void modifiedCheckBoxActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_modifiedCheckBoxActionPerformed
-        pcs.firePropertyChange(FileSearchPanel.EVENT.CHECKED.toString(), null, null);
+        firePropertyChange(FileSearchPanel.EVENT.CHECKED.toString(), null, null);
     }//GEN-LAST:event_modifiedCheckBoxActionPerformed
 
     private void accessedCheckBoxActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_accessedCheckBoxActionPerformed
-        pcs.firePropertyChange(FileSearchPanel.EVENT.CHECKED.toString(), null, null);
+        firePropertyChange(FileSearchPanel.EVENT.CHECKED.toString(), null, null);
     }//GEN-LAST:event_accessedCheckBoxActionPerformed
 
     private void createdCheckBoxActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_createdCheckBoxActionPerformed
-        pcs.firePropertyChange(FileSearchPanel.EVENT.CHECKED.toString(), null, null);
+        firePropertyChange(FileSearchPanel.EVENT.CHECKED.toString(), null, null);
     }//GEN-LAST:event_createdCheckBoxActionPerformed
 
     private void changedCheckBoxActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_changedCheckBoxActionPerformed
-        pcs.firePropertyChange(FileSearchPanel.EVENT.CHECKED.toString(), null, null);
+        firePropertyChange(FileSearchPanel.EVENT.CHECKED.toString(), null, null);
     }//GEN-LAST:event_changedCheckBoxActionPerformed
 
     /**

--- a/Core/src/org/sleuthkit/autopsy/filesearch/KnownStatusSearchPanel.java
+++ b/Core/src/org/sleuthkit/autopsy/filesearch/KnownStatusSearchPanel.java
@@ -24,8 +24,6 @@
  */
 package org.sleuthkit.autopsy.filesearch;
 
-import java.beans.PropertyChangeListener;
-import java.beans.PropertyChangeSupport;
 import javax.swing.JCheckBox;
 
 /**
@@ -33,8 +31,6 @@ import javax.swing.JCheckBox;
  * @author pmartel
  */
 class KnownStatusSearchPanel extends javax.swing.JPanel {
-
-    private final PropertyChangeSupport pcs = new PropertyChangeSupport(this);
 
     /**
      * Creates new form KnownStatusSearchPanel
@@ -65,16 +61,6 @@ class KnownStatusSearchPanel extends javax.swing.JPanel {
         this.unknownOptionCheckBox.setEnabled(enabled);
         this.knownOptionCheckBox.setEnabled(enabled);
         this.knownBadOptionCheckBox.setEnabled(enabled);
-    }
-
-    @Override
-    public void addPropertyChangeListener(PropertyChangeListener pcl) {
-        pcs.addPropertyChangeListener(pcl);
-    }
-
-    @Override
-    public void removePropertyChangeListener(PropertyChangeListener pcl) {
-        pcs.removePropertyChangeListener(pcl);
     }
 
     boolean isValidSearch() {
@@ -155,20 +141,20 @@ class KnownStatusSearchPanel extends javax.swing.JPanel {
     }// </editor-fold>//GEN-END:initComponents
 
     private void knownOptionCheckBoxActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_knownOptionCheckBoxActionPerformed
-        pcs.firePropertyChange(FileSearchPanel.EVENT.CHECKED.toString(), null, null);
+        firePropertyChange(FileSearchPanel.EVENT.CHECKED.toString(), null, null);
     }//GEN-LAST:event_knownOptionCheckBoxActionPerformed
 
     private void knownCheckBoxActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_knownCheckBoxActionPerformed
         setComponentsEnabled();
-        pcs.firePropertyChange(FileSearchPanel.EVENT.CHECKED.toString(), null, null);
+        firePropertyChange(FileSearchPanel.EVENT.CHECKED.toString(), null, null);
     }//GEN-LAST:event_knownCheckBoxActionPerformed
 
     private void unknownOptionCheckBoxActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_unknownOptionCheckBoxActionPerformed
-        pcs.firePropertyChange(FileSearchPanel.EVENT.CHECKED.toString(), null, null);
+        firePropertyChange(FileSearchPanel.EVENT.CHECKED.toString(), null, null);
     }//GEN-LAST:event_unknownOptionCheckBoxActionPerformed
 
     private void knownBadOptionCheckBoxActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_knownBadOptionCheckBoxActionPerformed
-        pcs.firePropertyChange(FileSearchPanel.EVENT.CHECKED.toString(), null, null);
+        firePropertyChange(FileSearchPanel.EVENT.CHECKED.toString(), null, null);
     }//GEN-LAST:event_knownBadOptionCheckBoxActionPerformed
 
     // Variables declaration - do not modify//GEN-BEGIN:variables

--- a/Core/src/org/sleuthkit/autopsy/filesearch/MimeTypePanel.java
+++ b/Core/src/org/sleuthkit/autopsy/filesearch/MimeTypePanel.java
@@ -6,7 +6,6 @@
 package org.sleuthkit.autopsy.filesearch;
 
 import java.beans.PropertyChangeListener;
-import java.beans.PropertyChangeSupport;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -29,7 +28,6 @@ public class MimeTypePanel extends javax.swing.JPanel {
     private static final SortedSet<MediaType> mediaTypes = MimeTypes.getDefaultMimeTypes().getMediaTypeRegistry().getTypes();
     private static final Logger logger = Logger.getLogger(MimeTypePanel.class.getName());
     private static final long serialVersionUID = 1L;
-    private final PropertyChangeSupport pcs = new PropertyChangeSupport(this);
 
     /**
      * Creates new form MimeTypePanel
@@ -40,7 +38,7 @@ public class MimeTypePanel extends javax.swing.JPanel {
         this.mimeTypeList.addListSelectionListener(new ListSelectionListener() {
             @Override
             public void valueChanged(ListSelectionEvent e) {
-                pcs.firePropertyChange(FileSearchPanel.EVENT.CHECKED.toString(), null, null);
+                firePropertyChange(FileSearchPanel.EVENT.CHECKED.toString(), null, null);
             }
         });
     }
@@ -85,16 +83,6 @@ public class MimeTypePanel extends javax.swing.JPanel {
         boolean enabled = this.isSelected();
         this.mimeTypeList.setEnabled(enabled);
         this.jLabel1.setEnabled(enabled);
-    }
-    
-    @Override
-    public void addPropertyChangeListener(PropertyChangeListener pcl) {
-        pcs.addPropertyChangeListener(pcl);
-    }
-
-    @Override
-    public void removePropertyChangeListener(PropertyChangeListener pcl) {
-        pcs.removePropertyChangeListener(pcl);
     }
 
     /**
@@ -162,7 +150,7 @@ public class MimeTypePanel extends javax.swing.JPanel {
 
     private void mimeTypeCheckBoxActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_mimeTypeCheckBoxActionPerformed
         setComponentsEnabled();
-        pcs.firePropertyChange(FileSearchPanel.EVENT.CHECKED.toString(), null, null);
+        firePropertyChange(FileSearchPanel.EVENT.CHECKED.toString(), null, null);
         this.mimeTypeList.setSelectedIndices(new int[0]);
     }//GEN-LAST:event_mimeTypeCheckBoxActionPerformed
 

--- a/Core/src/org/sleuthkit/autopsy/filesearch/NameSearchPanel.java
+++ b/Core/src/org/sleuthkit/autopsy/filesearch/NameSearchPanel.java
@@ -27,7 +27,6 @@ package org.sleuthkit.autopsy.filesearch;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.beans.PropertyChangeListener;
-import java.beans.PropertyChangeSupport;
 import javax.swing.JCheckBox;
 import javax.swing.JMenuItem;
 import javax.swing.JTextField;
@@ -39,8 +38,6 @@ import javax.swing.event.DocumentListener;
  * @author pmartel
  */
 class NameSearchPanel extends javax.swing.JPanel {
-
-    private final PropertyChangeSupport pcs = new PropertyChangeSupport(this);
 
     /**
      * Creates new form NameSearchPanel
@@ -76,17 +73,17 @@ class NameSearchPanel extends javax.swing.JPanel {
         this.searchTextField.getDocument().addDocumentListener(new DocumentListener() {
             @Override
             public void insertUpdate(DocumentEvent e) {
-                pcs.firePropertyChange(FileSearchPanel.EVENT.CHECKED.toString(), null, null);
+                firePropertyChange(FileSearchPanel.EVENT.CHECKED.toString(), null, null);
             }
 
             @Override
             public void removeUpdate(DocumentEvent e) {
-                pcs.firePropertyChange(FileSearchPanel.EVENT.CHECKED.toString(), null, null);
+                firePropertyChange(FileSearchPanel.EVENT.CHECKED.toString(), null, null);
             }
 
             @Override
             public void changedUpdate(DocumentEvent e) {
-                pcs.firePropertyChange(FileSearchPanel.EVENT.CHECKED.toString(), null, null);
+                firePropertyChange(FileSearchPanel.EVENT.CHECKED.toString(), null, null);
             }
         });
 
@@ -104,16 +101,6 @@ class NameSearchPanel extends javax.swing.JPanel {
         boolean enabled = nameCheckBox.isSelected();
         this.searchTextField.setEnabled(enabled);
         this.noteNameLabel.setEnabled(enabled);
-    }
-    
-    @Override
-    public void addPropertyChangeListener(PropertyChangeListener pcl) {
-        pcs.addPropertyChangeListener(pcl);
-    }
-
-    @Override
-    public void removePropertyChangeListener(PropertyChangeListener pcl) {
-        pcs.removePropertyChangeListener(pcl);
     }
 
     /**
@@ -200,7 +187,7 @@ class NameSearchPanel extends javax.swing.JPanel {
 
     private void nameCheckBoxActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_nameCheckBoxActionPerformed
         setComponentsEnabled();
-        pcs.firePropertyChange(FileSearchPanel.EVENT.CHECKED.toString(), null, null);
+        firePropertyChange(FileSearchPanel.EVENT.CHECKED.toString(), null, null);
     }//GEN-LAST:event_nameCheckBoxActionPerformed
 
     // Variables declaration - do not modify//GEN-BEGIN:variables

--- a/Core/src/org/sleuthkit/autopsy/filesearch/SizeSearchPanel.java
+++ b/Core/src/org/sleuthkit/autopsy/filesearch/SizeSearchPanel.java
@@ -20,8 +20,6 @@ package org.sleuthkit.autopsy.filesearch;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.beans.PropertyChangeListener;
-import java.beans.PropertyChangeSupport;
 import java.text.NumberFormat;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
@@ -33,8 +31,6 @@ import javax.swing.JMenuItem;
  * @author pmartel
  */
 class SizeSearchPanel extends javax.swing.JPanel {
-
-    private final PropertyChangeSupport pcs = new PropertyChangeSupport(this);
 
     /**
      * Creates new form SizeSearchPanel
@@ -91,16 +87,6 @@ class SizeSearchPanel extends javax.swing.JPanel {
         this.sizeCompareComboBox.setEnabled(enabled);
         this.sizeUnitComboBox.setEnabled(enabled);
         this.sizeTextField.setEnabled(enabled);
-    }
-    
-    @Override
-    public void addPropertyChangeListener(PropertyChangeListener pcl) {
-        pcs.addPropertyChangeListener(pcl);
-    }
-
-    @Override
-    public void removePropertyChangeListener(PropertyChangeListener pcl) {
-        pcs.removePropertyChangeListener(pcl);
     }
 
     /**
@@ -182,7 +168,7 @@ class SizeSearchPanel extends javax.swing.JPanel {
 
     private void sizeCheckBoxActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_sizeCheckBoxActionPerformed
         setComponentsEnabled();
-        pcs.firePropertyChange(FileSearchPanel.EVENT.CHECKED.toString(), null, null);
+        firePropertyChange(FileSearchPanel.EVENT.CHECKED.toString(), null, null);
     }//GEN-LAST:event_sizeCheckBoxActionPerformed
 
     // Variables declaration - do not modify//GEN-BEGIN:variables

--- a/Core/src/org/sleuthkit/autopsy/report/ReportProgressPanel.java
+++ b/Core/src/org/sleuthkit/autopsy/report/ReportProgressPanel.java
@@ -22,8 +22,6 @@ import org.openide.util.NbBundle;
 import java.awt.*;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
-import java.beans.PropertyChangeListener;
-import java.beans.PropertyChangeSupport;
 import java.io.File;
 import java.io.IOException;
 import java.util.logging.Level;
@@ -38,7 +36,6 @@ public class ReportProgressPanel extends javax.swing.JPanel {
     private static final Logger logger = Logger.getLogger(ReportProgressPanel.class.getName());
     private static final Color GREEN = new Color(50, 205, 50);
     private static final Color RED = new Color(178, 34, 34);
-    private final PropertyChangeSupport pcs = new PropertyChangeSupport(this);
     private ReportStatus status;
 
     /**
@@ -113,26 +110,6 @@ public class ReportProgressPanel extends javax.swing.JPanel {
         } else {
             pathLabel.setText(NbBundle.getMessage(this.getClass(), "ReportProgressPanel.initPathLabel.noFile"));
         }
-    }
-
-    /**
-     * Adds a property change listener to this panel.
-     *
-     * @param listener The listener to be added.
-     */
-    @Override
-    public void addPropertyChangeListener(PropertyChangeListener listener) {
-        this.pcs.addPropertyChangeListener(listener);
-    }
-
-    /**
-     * Removes a property change listener from this panel.
-     *
-     * @param listener The listener to be removed.
-     */
-    @Override
-    public void removePropertyChangeListener(PropertyChangeListener listener) {
-        this.pcs.removePropertyChangeListener(listener);
     }
 
     /**
@@ -242,7 +219,7 @@ public class ReportProgressPanel extends javax.swing.JPanel {
                         reportProgressBar.setStringPainted(true);
                         reportProgressBar.setForeground(GREEN);
                         reportProgressBar.setString("Complete"); //NON-NLS
-                        pcs.firePropertyChange(ReportStatus.COMPLETE.toString(), oldValue, status);
+                        firePropertyChange(ReportStatus.COMPLETE.toString(), oldValue, status);
                         break;
                     }
                     case ERROR: {
@@ -254,7 +231,7 @@ public class ReportProgressPanel extends javax.swing.JPanel {
                         reportProgressBar.setStringPainted(true);
                         reportProgressBar.setForeground(RED);
                         reportProgressBar.setString("Error"); //NON-NLS
-                        pcs.firePropertyChange(ReportStatus.COMPLETE.toString(), oldValue, status);
+                        firePropertyChange(ReportStatus.COMPLETE.toString(), oldValue, status);
                         break;
                     }
                     default: {
@@ -285,7 +262,7 @@ public class ReportProgressPanel extends javax.swing.JPanel {
                 reportProgressBar.setStringPainted(true);
                 reportProgressBar.setForeground(RED); // Red
                 reportProgressBar.setString("Cancelled"); //NON-NLS
-                pcs.firePropertyChange(ReportStatus.CANCELED.toString(), oldValue, status);
+                firePropertyChange(ReportStatus.CANCELED.toString(), oldValue, status);
                 statusMessageLabel.setForeground(RED);
                 statusMessageLabel.setText(NbBundle.getMessage(this.getClass(), "ReportProgressPanel.cancel.procLbl.text"));
                 break;

--- a/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/GlobalEditListPanel.java
+++ b/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/GlobalEditListPanel.java
@@ -23,7 +23,6 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.beans.PropertyChangeSupport;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -47,7 +46,6 @@ import org.sleuthkit.autopsy.coreutils.Logger;
 import org.sleuthkit.autopsy.ingest.IngestManager;
 import java.awt.Component;
 import javax.swing.ImageIcon;
-import javax.swing.JLabel;
 import static javax.swing.SwingConstants.CENTER;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableCellRenderer;
@@ -62,7 +60,6 @@ class GlobalEditListPanel extends javax.swing.JPanel implements ListSelectionLis
     private static final long serialVersionUID = 1L;
     private final KeywordTableModel tableModel;
     private KeywordList currentKeywordList;
-    private final PropertyChangeSupport pcs = new PropertyChangeSupport(this);
 
     /**
      * Creates new form GlobalEditListPanel
@@ -148,16 +145,6 @@ class GlobalEditListPanel extends javax.swing.JPanel implements ListSelectionLis
                 }
             }
         });
-    }
-
-    @Override
-    public void addPropertyChangeListener(PropertyChangeListener l) {
-        pcs.addPropertyChangeListener(l);
-    }
-
-    @Override
-    public void removePropertyChangeListener(PropertyChangeListener l) {
-        pcs.removePropertyChangeListener(l);
     }
 
     void setButtonStates() {
@@ -453,7 +440,7 @@ class GlobalEditListPanel extends javax.swing.JPanel implements ListSelectionLis
         XmlKeywordSearchList.getCurrent().addList(currentKeywordList);
         chRegex.setSelected(false);
         addWordField.setText("");
-        pcs.firePropertyChange(OptionsPanelController.PROP_CHANGED, null, null);
+        firePropertyChange(OptionsPanelController.PROP_CHANGED, null, null);
         setFocusOnKeywordTextBox();
         setButtonStates();
     }//GEN-LAST:event_addWordButtonActionPerformed
@@ -464,7 +451,7 @@ class GlobalEditListPanel extends javax.swing.JPanel implements ListSelectionLis
             tableModel.deleteSelected(keywordTable.getSelectedRows());
             XmlKeywordSearchList.getCurrent().addList(currentKeywordList);
             setButtonStates();
-            pcs.firePropertyChange(OptionsPanelController.PROP_CHANGED, null, null);
+            firePropertyChange(OptionsPanelController.PROP_CHANGED, null, null);
         }
     }//GEN-LAST:event_deleteWordButtonActionPerformed
 
@@ -527,11 +514,11 @@ class GlobalEditListPanel extends javax.swing.JPanel implements ListSelectionLis
         currentKeywordList.setIngestMessages(ingestMessagesCheckbox.isSelected());
         XmlKeywordSearchList updater = XmlKeywordSearchList.getCurrent();
         updater.addList(currentKeywordList);
-        pcs.firePropertyChange(OptionsPanelController.PROP_CHANGED, null, null);
+        firePropertyChange(OptionsPanelController.PROP_CHANGED, null, null);
     }//GEN-LAST:event_ingestMessagesCheckboxActionPerformed
 
     private void deleteListButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_deleteListButtonActionPerformed
-        pcs.firePropertyChange(OptionsPanelController.PROP_CHANGED, null, null);
+        firePropertyChange(OptionsPanelController.PROP_CHANGED, null, null);
     }//GEN-LAST:event_deleteListButtonActionPerformed
 
     // Variables declaration - do not modify//GEN-BEGIN:variables

--- a/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/GlobalListsManagementPanel.java
+++ b/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/GlobalListsManagementPanel.java
@@ -19,8 +19,6 @@
 package org.sleuthkit.autopsy.keywordsearch;
 
 import java.awt.event.KeyEvent;
-import java.beans.PropertyChangeListener;
-import java.beans.PropertyChangeSupport;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -44,7 +42,6 @@ class GlobalListsManagementPanel extends javax.swing.JPanel implements OptionsPa
 
     private Logger logger = Logger.getLogger(GlobalListsManagementPanel.class.getName());
     private KeywordListTableModel tableModel;
-    private final PropertyChangeSupport pcs = new PropertyChangeSupport(this);
     private final org.sleuthkit.autopsy.keywordsearch.GlobalListSettingsPanel globalListSettingsPanel;
 
     GlobalListsManagementPanel(org.sleuthkit.autopsy.keywordsearch.GlobalListSettingsPanel gsp) {
@@ -88,16 +85,6 @@ class GlobalListsManagementPanel extends javax.swing.JPanel implements OptionsPa
          * listsTable.getSelectionModel().setSelectionInterval(0, 0); } else {
          * listsTable.getSelectionModel().clearSelection(); } } } });
          */
-    }
-
-    @Override
-    public void addPropertyChangeListener(PropertyChangeListener l) {
-        pcs.addPropertyChangeListener(l);
-    }
-
-    @Override
-    public void removePropertyChangeListener(PropertyChangeListener l) {
-        pcs.removePropertyChangeListener(l);
     }
 
     /**
@@ -220,7 +207,7 @@ class GlobalListsManagementPanel extends javax.swing.JPanel implements OptionsPa
                 listsTable.getSelectionModel().addSelectionInterval(i, i);
             }
         }
-        pcs.firePropertyChange(OptionsPanelController.PROP_CHANGED, null, null);
+        firePropertyChange(OptionsPanelController.PROP_CHANGED, null, null);
         globalListSettingsPanel.setFocusOnKeywordTextBox();
     }//GEN-LAST:event_newListButtonActionPerformed
 
@@ -316,7 +303,7 @@ class GlobalListsManagementPanel extends javax.swing.JPanel implements OptionsPa
                 }
             }
         }
-        pcs.firePropertyChange(OptionsPanelController.PROP_CHANGED, null, null);
+        firePropertyChange(OptionsPanelController.PROP_CHANGED, null, null);
     }//GEN-LAST:event_importButtonActionPerformed
     private void listsTableKeyPressed(java.awt.event.KeyEvent evt) {//GEN-FIRST:event_listsTableKeyPressed
         if (evt.getKeyCode() == KeyEvent.VK_DELETE) {
@@ -326,7 +313,7 @@ class GlobalListsManagementPanel extends javax.swing.JPanel implements OptionsPa
             } else if (KeywordSearchUtil.displayConfirmDialog(NbBundle.getMessage(this.getClass(), "KeywordSearchConfigurationPanel1.customizeComponents.title"), NbBundle.getMessage(this.getClass(), "KeywordSearchConfigurationPanel1.customizeComponents.body"), KeywordSearchUtil.DIALOG_MESSAGE_TYPE.WARN)) {
                 String listName = (String) listsTable.getModel().getValueAt(selected[0], 0);
                 XmlKeywordSearchList.getCurrent().deleteList(listName);
-                pcs.firePropertyChange(OptionsPanelController.PROP_CHANGED, null, null);
+                firePropertyChange(OptionsPanelController.PROP_CHANGED, null, null);
             } else {
                 return;
             }


### PR DESCRIPTION
… linked to the filters in FileSearchPanel

LocalDiskPanel is used when adding a data source
DateSearchPanel, KnownStatusSearchPanel, MimeTypePanel, NameSearchPanel, and SizeSearchPanel are used when searching with filters. When a combination with valid settings are selected, the search button is enabled.