### PR TITLE
2020: instead of passing a msg from getLocalizedMessage() method, pas…

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/modules/stix/STIXReportModule.java
+++ b/Core/src/org/sleuthkit/autopsy/modules/stix/STIXReportModule.java
@@ -172,11 +172,13 @@ public class STIXReportModule implements GeneralReportModule {
                 try {
                     processFile(file.getAbsolutePath(), progressPanel, output);
                 } catch (TskCoreException | JAXBException ex) {
-                    logger.log(Level.SEVERE, String.format("Unable to process STIX file %s", file), ex); //NON-NLS
+                    String errMsg = String.format("Unable to process STIX file %s", file);
+                    logger.log(Level.SEVERE, errMsg, ex); //NON-NLS
                     MessageNotifyUtil.Notify.show("STIXReportModule", //NON-NLS
-                            ex.getLocalizedMessage(),
+                            errMsg,
                             MessageNotifyUtil.MessageType.ERROR);
                     hadErrors = true;
+                    break;
                 }
                 // Clear out the ID maps before loading the next file
                 idToObjectMap = new HashMap<String, ObjectType>();


### PR DESCRIPTION
If anything error/exception we get, we will stop processing the rest of the files in the stix directory, so I didn't separately handling TskCoreException and JAXException. Also we are not going to show details error message on at UI to notify the user. All stack trace and exceptions are logged in the log file. 