### PR TITLE
Clearing and filling hashmap now wrapped by same synchronized block

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/datamodel/FileTypesByMimeType.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/FileTypesByMimeType.java
@@ -75,9 +75,7 @@ public final class FileTypesByMimeType extends Observable implements AutopsyVisi
     private final PropertyChangeListener pcl = (PropertyChangeEvent evt) -> {
         String eventType = evt.getPropertyName();
         if (eventType.equals(IngestManager.IngestJobEvent.COMPLETED.toString())
-                || eventType.equals(IngestManager.IngestJobEvent.CANCELLED.toString())
-                //             || eventType.equals(Case.Events.DATA_SOURCE_ADDED.toString())
-                || eventType.equals(IngestManager.IngestModuleEvent.CONTENT_CHANGED.toString())) {
+                || eventType.equals(IngestManager.IngestJobEvent.CANCELLED.toString())) {
             /**
              * Checking for a current case is a stop gap measure until a
              * different way of handling the closing of cases is worked out.
@@ -123,15 +121,13 @@ public final class FileTypesByMimeType extends Observable implements AutopsyVisi
         allDistinctMimeTypesQuery.append(TskData.TSK_DB_FILES_TYPE_ENUM.LOCAL.ordinal()).append("))");
         synchronized (existingMimeTypes) {
             existingMimeTypes.clear();
-        }
 
-        if (skCase == null) {
+            if (skCase == null) {
 
-            return;
-        }
-        try (SleuthkitCase.CaseDbQuery dbQuery = skCase.executeQuery(allDistinctMimeTypesQuery.toString())) {
-            ResultSet resultSet = dbQuery.getResultSet();
-            synchronized (existingMimeTypes) {
+                return;
+            }
+            try (SleuthkitCase.CaseDbQuery dbQuery = skCase.executeQuery(allDistinctMimeTypesQuery.toString())) {
+                ResultSet resultSet = dbQuery.getResultSet();
                 while (resultSet.next()) {
                     final String mime_type = resultSet.getString("mime_type"); //NON-NLS
                     if (!mime_type.isEmpty()) {
@@ -144,17 +140,18 @@ public final class FileTypesByMimeType extends Observable implements AutopsyVisi
                         }
                     }
                 }
+            } catch (TskCoreException | SQLException ex) {
+                LOGGER.log(Level.WARNING, "Unable to populate File Types by MIME Type tree view from DB: ", ex); //NON-NLS
             }
-        } catch (TskCoreException | SQLException ex) {
-            LOGGER.log(Level.WARNING, "Unable to populate File Types by MIME Type tree view from DB: ", ex); //NON-NLS
         }
+
         setChanged();
+
         notifyObservers();
     }
 
     FileTypesByMimeType(SleuthkitCase skCase) {
         IngestManager.getInstance().addIngestJobEventListener(pcl);
-        IngestManager.getInstance().addIngestModuleEventListener(pcl);
         this.skCase = skCase;
         populateHashMap();
     }
@@ -178,6 +175,7 @@ public final class FileTypesByMimeType extends Observable implements AutopsyVisi
             isEmptyMimeNode = true;
         }
         return isEmptyMimeNode;
+
     }
 
     /**


### PR DESCRIPTION
Removes possibility for null pointer error that would happen sometimes due to trying to add all of an empty container to a list. 

Also removes updates to mime type tree on content_added events, to lower number of queries during embedded file extractor.