### PR TITLE
fix npe when a hit is in the file name and so the  "parent" index ent…

### DIFF
--- a/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/LuceneQuery.java
+++ b/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/LuceneQuery.java
@@ -223,8 +223,8 @@ class LuceneQuery implements KeywordSearchQuery {
                     final Integer chunkSize = (Integer) resultDoc.getFieldValue(Server.Schema.CHUNK_SIZE.toString());
                     final String content_str = resultDoc.get(Server.Schema.CONTENT_STR.toString()).toString();
 
-                    Integer firstOccurence = content_str.indexOf(strippedQueryString);
-                    if (firstOccurence < chunkSize) {
+                    int firstOccurence = content_str.indexOf(strippedQueryString);
+                    if (chunkSize != null && firstOccurence < chunkSize) {
                         matches.add(createKeywordtHit(highlightResponse, docId));
                     }
                 } catch (TskException ex) {

--- a/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/RegexQuery.java
+++ b/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/RegexQuery.java
@@ -243,7 +243,7 @@ final class RegexQuery implements KeywordSearchQuery {
         while (hitMatcher.find(offset)) {
             StringBuilder snippet = new StringBuilder();
 
-            if (hitMatcher.start() >= chunkSize) {
+            if (chunkSize != null && hitMatcher.start() >= chunkSize) {
                 break;
             }
 


### PR DESCRIPTION
…ry is returned, which does not include a chunksize.  Allways accept these hits.