### PR TITLE
Better handling of core being closed

### DIFF
--- a/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/DropdownToolbar.java
+++ b/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/DropdownToolbar.java
@@ -189,7 +189,7 @@ class DropdownToolbar extends javax.swing.JPanel {
                                     disableSearch = true;
                                 }
                             }
-                        } catch (KeywordSearchModuleException ex) {
+                        } catch (NoOpenCoreException ex) {
                             /*
                              * Error, disable the ad hoc search UI components.
                              */

--- a/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/Ingester.java
+++ b/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/Ingester.java
@@ -227,7 +227,7 @@ class Ingester {
             solrServer.addDocument(updateDoc);
             uncommitedIngests = true;
 
-        } catch (KeywordSearchModuleException ex) {
+        } catch (KeywordSearchModuleException | NoOpenCoreException ex) {
             //JMTODO: does this need to be internationalized?
             throw new IngesterException(
                     NbBundle.getMessage(Ingester.class, "Ingester.ingest.exception.err.msg", sourceName), ex);

--- a/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/KeywordSearchIngestModule.java
+++ b/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/KeywordSearchIngestModule.java
@@ -166,7 +166,7 @@ public final class KeywordSearchIngestModule implements FileIngestModule {
             if (!IndexFinder.getCurrentSchemaVersion().equals(indexInfo.getSchemaVersion())) {
                 throw new IngestModuleException(Bundle.KeywordSearchIngestModule_startupException_indexSchemaNotSupported(indexInfo.getSchemaVersion()));                
             }
-        } catch (KeywordSearchModuleException ex) {
+        } catch (NoOpenCoreException ex) {
             throw new IngestModuleException(Bundle.KeywordSearchIngestModule_startupMessage_failedToGetIndexSchema(), ex);
         }
 

--- a/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/SolrSearchService.java
+++ b/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/SolrSearchService.java
@@ -375,7 +375,7 @@ public class SolrSearchService implements KeywordSearchService, AutopsyService {
 
         try {
             KeywordSearch.getServer().closeCore();
-        } catch (KeywordSearchModuleException ex) {
+        } catch (KeywordSearchModuleException | NoOpenCoreException ex) {
             throw new AutopsyServiceException(String.format("Failed to close core for %s", context.getCase().getCaseDirectory()), ex);
         }
     }


### PR DESCRIPTION
* Server.addDocument() checks if a core is open before using it
* Several other methods now throw NoOpenCoreException instead of either silently doing nothing or throwing a generic KeywordSearchModuleException