### PR TITLE
Truncate case db name only

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/casemodule/Case.java
+++ b/Core/src/org/sleuthkit/autopsy/casemodule/Case.java
@@ -725,56 +725,88 @@ public class Case {
     }
 
     /**
-     * Cleans up the display name for a case to make a suitable case name for
-     * use in case direcotry paths, coordination service locks, PostgreSQL
-     * database names, Active MQ message message channels, etc.
-     *
-     * PostgreSQL:
-     * http://www.postgresql.org/docs/9.4/static/sql-syntax-lexical.html 63
-     * chars max, must start with a-z or _ following chars can be letters _ or
-     * digits
+     * Transforms the display name for a case to make a suitable case name for
+     * use in case directory paths, coordination service locks, Active MQ
+     * message message channels, etc.
      *
      * ActiveMQ:
      * http://activemq.2283324.n4.nabble.com/What-are-limitations-restrictions-on-destination-name-td4664141.html
      * may not be ?
      *
-     * @param caseName A candidate case name.
+     * @param displayName A candidate case name.
      *
      * @return The sanitized case name.
      *
      * @throws org.sleuthkit.autopsy.casemodule.Case.IllegalCaseNameException
      */
-    public static String displayNameToCaseName(String caseName) throws IllegalCaseNameException {
+    public static String displayNameToCaseName(String displayName) throws IllegalCaseNameException {
 
-        String result;
+        /*
+         * Remove all non-ASCII characters.
+         */
+        String caseName = displayName.replaceAll("[^\\p{ASCII}]", "_"); //NON-NLS
 
-        // Remove all non-ASCII characters
-        result = caseName.replaceAll("[^\\p{ASCII}]", "_"); //NON-NLS
+        /*
+         * Remove all control characters.
+         */
+        caseName = caseName.replaceAll("[\\p{Cntrl}]", "_"); //NON-NLS
 
-        // Remove all control characters
-        result = result.replaceAll("[\\p{Cntrl}]", "_"); //NON-NLS
+        /*
+         * Remove /, \, :, ?, space, ' ".
+         */
+        caseName = caseName.replaceAll("[ /?:'\"\\\\]", "_"); //NON-NLS
 
-        // Remove / \ : ? space ' "
-        result = result.replaceAll("[ /?:'\"\\\\]", "_"); //NON-NLS
+        /*
+         * Make it all lowercase.
+         */
+        caseName = caseName.toLowerCase();
 
-        // Make it all lowercase
-        result = result.toLowerCase();
-
-        // Must start with letter or underscore for PostgreSQL. If not, prepend an underscore.
-        if (result.length() > 0 && !(Character.isLetter(result.codePointAt(0))) && !(result.codePointAt(0) == '_')) {
-            result = "_" + result;
+        if (caseName.isEmpty()) {
+            throw new IllegalCaseNameException(String.format("Failed to convert case name '%s'", displayName));
         }
 
-        // Chop to 63-16=47 left (63 max for PostgreSQL, taking 16 for the date _20151225_123456)
-        if (result.length() > MAX_SANITIZED_CASE_NAME_LEN) {
-            result = result.substring(0, MAX_SANITIZED_CASE_NAME_LEN);
+        return caseName;
+    }
+
+    /**
+     * Transforms a candidate name for a PostgreSQL database into a name that
+     * can be safely used in SQL commands as described at
+     * http://www.postgresql.org/docs/9.4/static/sql-syntax-lexical.html: 63
+     * chars max, must start with a letter or underscore, following chars can be
+     * letters, underscores, or digits. A timestamp suffix is added to ensure
+     * uniqueness.
+     *
+     * @param candidateName The candidate name.
+     *
+     * @return The transformed name.
+     */
+    private static String makePostgreSqlDbName(String candidateName) throws IllegalCaseNameException {
+
+        /*
+         * Apply the same transformations as are used for case names, for
+         * consistency.
+         */
+        String dbName = displayNameToCaseName(candidateName);
+
+        /*
+         * Must start with letter or underscore. If not, prepend an underscore.
+         */
+        if (dbName.length() > 0 && !(Character.isLetter(dbName.codePointAt(0))) && !(dbName.codePointAt(0) == '_')) {
+            dbName = "_" + dbName;
         }
 
-        if (result.isEmpty()) {
-            throw new IllegalCaseNameException(String.format("Failed to sanitize case name '%s'", caseName));
+        /*
+         * Truncate to 63-16=47 chars to accomodate the timestamp, then add the
+         * suffix.
+         */
+        if (dbName.length() > MAX_SANITIZED_CASE_NAME_LEN) {
+            dbName = dbName.substring(0, MAX_SANITIZED_CASE_NAME_LEN);
         }
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMdd_HHmmss");
+        Date date = new Date();
+        dbName = dbName + "_" + dateFormat.format(date);
 
-        return result;
+        return dbName;
     }
 
     /**
@@ -1740,6 +1772,7 @@ public class Case {
     @Messages({
         "Case.progressMessage.creatingCaseDirectory=Creating case directory...",
         "Case.progressMessage.creatingCaseDatabase=Creating case database...",
+        "Case.exceptionMessage.couldNotCreateCaseDatabaseName=Failed to create case database name from case name.",
         "Case.progressMessage.creatingCaseMetadataFile=Creating case metadata file...",
         "Case.exceptionMessage.couldNotCreateMetadataFile=Failed to create case metadata file.",
         "Case.exceptionMessage.couldNotCreateCaseDatabase=Failed to create case database."
@@ -1777,23 +1810,25 @@ public class Case {
         String dbName = null;
         try {
             if (CaseType.SINGLE_USER_CASE == caseType) {
+                dbName = SINGLE_USER_CASE_DB_NAME;
+            } else if (CaseType.MULTI_USER_CASE == caseType) {
+                dbName = makePostgreSqlDbName(caseName);
+            }
+        } catch (IllegalCaseNameException ex) {
+            throw new CaseActionException(Bundle.Case_exceptionMessage_couldNotCreateCaseDatabaseName(), ex);
+        }
+        try {
+            if (CaseType.SINGLE_USER_CASE == caseType) {
                 /*
                  * For single-user cases, the case database is a SQLite database
-                 * with a fixed name and is physically located in the root of
-                 * the case directory.
+                 * physically located in the root of the case directory.
                  */
-                dbName = SINGLE_USER_CASE_DB_NAME;
                 this.caseDb = SleuthkitCase.newCase(Paths.get(caseDir, SINGLE_USER_CASE_DB_NAME).toString());
             } else if (CaseType.MULTI_USER_CASE == caseType) {
                 /*
                  * For multi-user cases, the case database is a PostgreSQL
-                 * database with a name consiting of the case name with a time
-                 * stamp suffix and is physically located on the database
-                 * server.
+                 * database physically located on the database server.
                  */
-                SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMdd_HHmmss");
-                Date date = new Date();
-                dbName = caseName + "_" + dateFormat.format(date);
                 this.caseDb = SleuthkitCase.newCase(dbName, UserPreferences.getDatabaseConnectionInfo(), caseDir);
             }
         } catch (TskCoreException ex) {

--- a/Experimental/src/org/sleuthkit/autopsy/experimental/autoingest/AutoIngestDashboard.java
+++ b/Experimental/src/org/sleuthkit/autopsy/experimental/autoingest/AutoIngestDashboard.java
@@ -57,6 +57,7 @@ import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.NbBundle;
 import org.openide.util.actions.CallableSystemAction;
+import org.openide.windows.WindowManager;
 import org.sleuthkit.autopsy.casemodule.CaseNewAction;
 import org.sleuthkit.autopsy.casemodule.CaseOpenAction;
 import org.sleuthkit.autopsy.core.ServicesMonitor;
@@ -181,7 +182,8 @@ public final class AutoIngestDashboard extends JPanel implements Observer {
      * controlling automated ingest for a single node within the cluster.
      */
     private AutoIngestDashboard() {
-        disableUiMenuActions();
+        //Disable the main window so they can only use the dashboard (if we used setVisible the taskBar icon would go away)
+         WindowManager.getDefault().getMainWindow().setEnabled(false);
         
         manager = AutoIngestManager.getInstance();
 
@@ -223,36 +225,6 @@ public final class AutoIngestDashboard extends JPanel implements Observer {
          * Must set this flag, otherwise pop up menus don't close properly.
          */
         UIManager.put("PopupMenu.consumeEventOnClose", false);
-    }
-    
-    private void disableUiMenuActions() {        
-        /*
-         * Disable the new case action in auto ingest mode.
-         */
-        CallableSystemAction.get(CaseNewAction.class).setEnabled(false);
-
-        /*
-         * Disable the new case action in auto ingest mode.
-         */
-        CallableSystemAction.get(CaseOpenAction.class).setEnabled(false);
-        CallableSystemAction.get(AutoIngestCaseOpenAction.class).setEnabled(false);
-
-        /*
-         * Permanently delete the "Open Recent Cases" item in the "Case" menu.
-         * This is quite drastic, as it also affects Autopsy standalone mode on
-         * this machine, but we need to make sure a user can't open case in
-         * automated ingest mode. "Open Recent Cases" item can't be disabled via 
-         * CallableSystemAction because of how it is defined in layer.xml, i.e. 
-         * it is defined as "folder", not "file". 
-         */
-        FileObject root = FileUtil.getConfigRoot();
-        FileObject openRecentCasesMenu = root.getFileObject("Menu/Case/OpenRecentCase");
-        if (openRecentCasesMenu != null) {
-            try {
-                openRecentCasesMenu.delete();
-            } catch (IOException ignore) {
-            }
-        }        
     }
 
     /**


### PR DESCRIPTION
For multi-user case, separates the creation of a case name from a display name from creation of a case database name. The goal is to not apply PostgreSQL-required name transformations to the case name, especially truncation.