### PR TITLE
Change to manifest file parsing (2600)

### DIFF
--- a/Experimental/src/org/sleuthkit/autopsy/experimental/autoingest/AutopsyManifestFileParser.java
+++ b/Experimental/src/org/sleuthkit/autopsy/experimental/autoingest/AutopsyManifestFileParser.java
@@ -39,7 +39,7 @@ import org.xml.sax.SAXException;
 public final class AutopsyManifestFileParser implements ManifestFileParser {
 
     private static final String MANIFEST_FILE_NAME_SIGNATURE = "_Manifest.xml";
-    private static final String ROOT_ELEM_TAG_NAME = "Manifest";
+    private static final String ROOT_ELEM_TAG_NAME = "AutopsyManifest";
     private static final String CASE_NAME_XPATH = "/Manifest/Collection/Name/text()";
     private static final String DEVICE_ID_XPATH = "/Manifest/Collection/Image/ID/text()";
     private static final String DATA_SOURCE_NAME_XPATH = "/Manifest/Collection/Image/Name/text()";


### PR DESCRIPTION
AutopsyManifestFileParser looks for 'AutopsyManifest' root element instead of 'Manifest' to resolve a customer's issue

IMPORTANT!!!! All existing Autopsy Manifest.xml files MUST be updated to use 'AutopsyManifest' root element!