### PR TITLE
Add static getTagDisplayNames API to TagsManager

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/casemodule/services/TagsManager.java
+++ b/Core/src/org/sleuthkit/autopsy/casemodule/services/TagsManager.java
@@ -72,6 +72,36 @@ public class TagsManager implements Closeable {
     }
 
     /**
+     * Gets the set of display names of the currently available tag types. This
+     * includes the display names of the standard tag types, the current user's
+     * custom tag types, and the tags in the case database of the current case
+     * (if there is a current case).
+     *
+     * @return A set, possibly empty, of tag type display names.
+     *
+     * @throws TskCoreException If there is a current case and there is an error
+     *                          querying the case database for tag types.
+     */
+    public static Set<String> getTagDisplayNames() throws TskCoreException {
+        Set<String> tagDisplayNames = new HashSet<>(STANDARD_TAG_DISPLAY_NAMES);
+        Set<TagNameDefiniton> customNames = TagNameDefiniton.getTagNameDefinitions();
+        customNames.forEach((tagType) -> {
+            tagDisplayNames.add(tagType.getDisplayName());
+        });        
+        try {
+            TagsManager tagsManager = Case.getCurrentCase().getServices().getTagsManager();
+            for (TagName tagName : tagsManager.getAllTagNames()) {
+                tagDisplayNames.add(tagName.getDisplayName());
+            }
+        } catch (IllegalStateException ignored) {
+            /*
+             * No current case, nothing more to add to the set.
+             */
+        } 
+        return tagDisplayNames;
+    }
+
+    /**
      * Constructs a per case Autopsy service that manages the addition of
      * content and artifact tags to the case database.
      *
@@ -140,7 +170,7 @@ public class TagsManager implements Closeable {
         }
         return new HashMap<>(tagNames);
     }
-    
+
     /**
      * Adds a tag name entry to the case database and adds a corresponding tag
      * type to the current user's custom tag types.

--- a/Experimental/src/org/sleuthkit/autopsy/experimental/enterpriseartifactsmanager/optionspanel/ManageTagsDialog.java
+++ b/Experimental/src/org/sleuthkit/autopsy/experimental/enterpriseartifactsmanager/optionspanel/ManageTagsDialog.java
@@ -30,6 +30,7 @@ import javax.swing.table.DefaultTableModel;
 import org.openide.util.NbBundle.Messages;
 import org.openide.windows.WindowManager;
 import org.sleuthkit.autopsy.casemodule.Case;
+import org.sleuthkit.autopsy.casemodule.services.TagsManager;
 import org.sleuthkit.autopsy.coreutils.Logger;
 import org.sleuthkit.datamodel.TskCoreException;
 import org.sleuthkit.autopsy.experimental.enterpriseartifactsmanager.datamodel.EamDb;
@@ -65,22 +66,21 @@ final class ManageTagsDialog extends javax.swing.JDialog {
 
         List<String> tagNames = new ArrayList<>(badTags);
         try {
-            if (Case.isCaseOpen()) {
-                tagNames.addAll(Case.getCurrentCase().getServices().getTagsManager().getAllTagNames().stream()
-                        .map(tag -> tag.getDisplayName())
-                        .filter(tagName -> !badTags.contains(tagName))
-                        .collect(Collectors.toList()));
-            }
+            tagNames.addAll(
+                    TagsManager.getTagDisplayNames()
+                    .stream()
+                    .filter(tagName -> !badTags.contains(tagName))
+                    .collect(Collectors.toList()));
         } catch (TskCoreException ex) {
             LOGGER.log(Level.WARNING, "Could not get list of tags in case", ex);
         }
 
         Collections.sort(tagNames);
 
-        DefaultTableModel model = (DefaultTableModel)tblTagNames.getModel();
+        DefaultTableModel model = (DefaultTableModel) tblTagNames.getModel();
         for (String tagName : tagNames) {
             boolean enabled = badTags.contains(tagName);
-            model.addRow(new Object[]{ tagName, enabled });
+            model.addRow(new Object[]{tagName, enabled});
         }
     }
 
@@ -191,10 +191,10 @@ final class ManageTagsDialog extends javax.swing.JDialog {
     private void setBadTags() {
         List<String> badTags = new ArrayList<>();
 
-        DefaultTableModel model = (DefaultTableModel)tblTagNames.getModel();
+        DefaultTableModel model = (DefaultTableModel) tblTagNames.getModel();
         for (int i = 0; i < model.getRowCount(); ++i) {
-            String tagName = (String)model.getValueAt(i, 0);
-            boolean enabled = (boolean)model.getValueAt(i, 1);
+            String tagName = (String) model.getValueAt(i, 0);
+            boolean enabled = (boolean) model.getValueAt(i, 1);
 
             if (enabled) {
                 badTags.add(tagName);


### PR DESCRIPTION
- Add static getTagDisplayNames API to TagsManager
- Call new API to populate tags list component in org.sleuthkit.autopsy.experimental.enterpriseartifactsmanager.optionspanel.ManageTagsDialog.