### PR TITLE
Convert sql statements referring to device name to use device id

### DIFF
--- a/Experimental/src/org/sleuthkit/autopsy/experimental/enterpriseartifactsmanager/datamodel/AbstractSqlEamDb.java
+++ b/Experimental/src/org/sleuthkit/autopsy/experimental/enterpriseartifactsmanager/datamodel/AbstractSqlEamDb.java
@@ -936,14 +936,15 @@ public abstract class AbstractSqlEamDb implements EamDb {
 
             sql.append("+ (SELECT count(*) FROM ");
             sql.append(table_name);
-            sql.append(" WHERE case_id=(SELECT id FROM cases WHERE case_uid=?))");// and data_source_id=(SELECT id FROM data_sources WHERE name=?))");
+            sql.append(" WHERE case_id=(SELECT id FROM cases WHERE case_uid=?) and data_source_id=(SELECT id FROM data_sources WHERE device_id=?))");
         }
 
         try {
             preparedStatement = conn.prepareStatement(sql.toString());
 
             for (int i = 0; i < artifactTypes.size(); ++i) {
-                preparedStatement.setString(i + 1, eamInstance.getEamCase().getCaseUUID());
+                preparedStatement.setString(2 * i + 1, eamInstance.getEamCase().getCaseUUID());
+                preparedStatement.setString(2 * i + 2, eamInstance.getEamDataSource().getDeviceID());
             }
 
             resultSet = preparedStatement.executeQuery();

--- a/branding/core/core.jar/org/netbeans/core/startup/Bundle.properties
+++ b/branding/core/core.jar/org/netbeans/core/startup/Bundle.properties
@@ -1,5 +1,5 @@
 #Updated by build script
-#Tue, 13 Jun 2017 12:57:15 -0400
+#Thu, 22 Jun 2017 08:50:21 -0400
 LBL_splash_window_title=Starting Autopsy
 SPLASH_HEIGHT=314
 SPLASH_WIDTH=538

--- a/branding/modules/org-netbeans-core-windows.jar/org/netbeans/core/windows/view/ui/Bundle.properties
+++ b/branding/modules/org-netbeans-core-windows.jar/org/netbeans/core/windows/view/ui/Bundle.properties
@@ -1,4 +1,4 @@
 #Updated by build script
-#Tue, 13 Jun 2017 12:57:15 -0400
+#Thu, 22 Jun 2017 08:50:21 -0400
 CTL_MainWindow_Title=Autopsy 4.4.1
 CTL_MainWindow_Title_No_Project=Autopsy 4.4.1


### PR DESCRIPTION
This plus 33e9dce resolves correlation engine issues 178 and 183 

I believe the duplicates issue was caused by old sql statements referring to device name rather than id, causing issues when ingesting images with the same name in testing. Was able to confirm that constraint violation SqlException gets thrown without this fix (due partially to running code based on our outdated fork), and is resolved with this fix. This PR resolves a few other locations where device_id should be used rather than name or was ignored.