### PR TITLE
Eam - properly use and display global files (hash db imported files)

### DIFF
--- a/Experimental/src/org/sleuthkit/autopsy/experimental/enterpriseartifactsmanager/contentviewer/DataContentViewerOtherCases.java
+++ b/Experimental/src/org/sleuthkit/autopsy/experimental/enterpriseartifactsmanager/contentviewer/DataContentViewerOtherCases.java
@@ -483,7 +483,7 @@ public class DataContentViewerOtherCases extends javax.swing.JPanel implements D
         Collection<EamArtifactInstance> eamArtifactInstances = new ArrayList<>();
         try {
             EamDb dbManager = EamDb.getInstance();
-            if (dbManager.getCorrelationArtifactTypeByName("FILES") == eamArtifact.getArtifactType()) {
+            if (dbManager.getCorrelationArtifactTypeByName("FILES").equals(eamArtifact.getArtifactType())) {
                 try {
                     Collection<EamGlobalFileInstance> eamGlobalFileInstances = dbManager.getGlobalFileInstancesByHash(eamArtifact.getArtifactValue());
                     for (EamGlobalFileInstance eamGlobalFileInstance : eamGlobalFileInstances) {

--- a/Experimental/src/org/sleuthkit/autopsy/experimental/enterpriseartifactsmanager/contentviewer/DataContentViewerOtherCasesTableModel.java
+++ b/Experimental/src/org/sleuthkit/autopsy/experimental/enterpriseartifactsmanager/contentviewer/DataContentViewerOtherCasesTableModel.java
@@ -133,13 +133,19 @@ public class DataContentViewerOtherCasesTableModel extends AbstractTableModel {
 
         switch (colId) {
             case CASE_NAME:
-                value = eamArtifactInstance.getEamCase().getDisplayName();
+                if (null != eamArtifactInstance.getEamCase()) {
+                    value = eamArtifactInstance.getEamCase().getDisplayName();
+                }
                 break;
             case DEVICE:
-                value = eamArtifactInstance.getEamDataSource().getDeviceID();
+                if (null != eamArtifactInstance.getEamDataSource()) {
+                    value = eamArtifactInstance.getEamDataSource().getDeviceID();
+                }
                 break;
             case DATA_SOURCE:
-                value = eamArtifactInstance.getEamDataSource().getName();
+                if (null != eamArtifactInstance.getEamDataSource()) {
+                    value = eamArtifactInstance.getEamDataSource().getName();
+                }
                 break;
             case FILE_PATH:
                 value = eamArtifactInstance.getFilePath();

--- a/Experimental/src/org/sleuthkit/autopsy/experimental/enterpriseartifactsmanager/datamodel/AbstractSqlEamDb.java
+++ b/Experimental/src/org/sleuthkit/autopsy/experimental/enterpriseartifactsmanager/datamodel/AbstractSqlEamDb.java
@@ -1204,7 +1204,7 @@ public abstract class AbstractSqlEamDb implements EamDb {
     public boolean isArtifactGlobalKnownBad(EamArtifact eamArtifact) throws EamDbException {
 
         // TEMP: Only support file types
-        if (eamArtifact.getArtifactType() != getCorrelationArtifactTypeByName("FILES")) {
+        if (!eamArtifact.getArtifactType().equals(getCorrelationArtifactTypeByName("FILES"))) {
             return false;
         }
 


### PR DESCRIPTION
- use .equals() instead of == for comparison of EamArtifact.Type objects. Now imported hash db files will properly trigger hashset hits. And imported hash db files will display in the content viewer table.
- check EamArtifactInstance fields for null before displaying them in the content viewer table. global files do not have a case or data source, so need to check for null before displaying them in the content viewer table. Those nulls will be replaced with "No data.". Could go with "" if you prefer.