### PR TITLE
Prevent empty strings from getting in the badTags list

### DIFF
--- a/CentralRepository/src/org/sleuthkit/autopsy/centralrepository/datamodel/PostgresEamDbSettings.java
+++ b/CentralRepository/src/org/sleuthkit/autopsy/centralrepository/datamodel/PostgresEamDbSettings.java
@@ -125,7 +125,11 @@ public final class PostgresEamDbSettings {
         if (badTagsStr == null || badTagsStr.isEmpty()) {
             badTagsStr = DEFAULT_BAD_TAGS;
         }
-        badTags = new ArrayList<>(Arrays.asList(badTagsStr.split(",")));
+        if(badTagsStr.isEmpty()){
+            badTags = new ArrayList<>();
+        } else {
+            badTags = new ArrayList<>(Arrays.asList(badTagsStr.split(",")));
+        }
     }
 
     public void saveSettings() {

--- a/CentralRepository/src/org/sleuthkit/autopsy/centralrepository/datamodel/SqliteEamDbSettings.java
+++ b/CentralRepository/src/org/sleuthkit/autopsy/centralrepository/datamodel/SqliteEamDbSettings.java
@@ -93,7 +93,11 @@ public final class SqliteEamDbSettings {
         if (badTagsStr == null || badTagsStr.isEmpty()) {
             badTagsStr = DEFAULT_BAD_TAGS;
         }
-        badTags = new ArrayList<>(Arrays.asList(badTagsStr.split(",")));
+        if(badTagsStr.isEmpty()){
+            badTags = new ArrayList<>();
+        } else {
+            badTags = new ArrayList<>(Arrays.asList(badTagsStr.split(",")));
+        }
     }
 
     public void saveSettings() {


### PR DESCRIPTION
Fix needed after https://github.com/sleuthkit/autopsy/pull/2970