### PR TITLE
Handling potential StackOverflowError coming out of Matcher.find() (2700)

### DIFF
--- a/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/RegexQuery.java
+++ b/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/RegexQuery.java
@@ -206,7 +206,7 @@ final class RegexQuery implements KeywordSearchQuery {
                         for (KeywordHit hit : keywordHits) {
                             hitsMultiMap.put(new Keyword(hit.getHit(), true, true, originalKeyword.getListName(), originalKeyword.getOriginalTerm()), hit);
                         }
-                    } catch (TskException ex) { 
+                    } catch (TskCoreException ex) { 
                         LOGGER.log(Level.SEVERE, "Error creating keyword hits", ex); //NON-NLS
                     }
                 }
@@ -228,7 +228,7 @@ final class RegexQuery implements KeywordSearchQuery {
         return results;
     }
 
-    private List<KeywordHit> createKeywordHits(SolrDocument solrDoc) throws TskException {
+    private List<KeywordHit> createKeywordHits(SolrDocument solrDoc) throws TskCoreException {
 
         List<KeywordHit> hits = new ArrayList<>();
         final String docId = solrDoc.getFieldValue(Server.Schema.ID.toString()).toString();

--- a/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/RegexQuery.java
+++ b/KeywordSearch/src/org/sleuthkit/autopsy/keywordsearch/RegexQuery.java
@@ -319,11 +319,11 @@ final class RegexQuery implements KeywordSearchQuery {
         } catch (TskCoreException ex) {
             throw ex;
         } catch (Throwable error) {
-            /* NOTE: Matcher.find() is known to throw StackOverflowError in rare cases (see story 2700). 
+            /* NOTE: Matcher.find() is known to throw StackOverflowError in rare cases (see JIRA-2700). 
             StackOverflowError is an error, not an exception, and therefore needs to be caught 
             as a Throwable. When this occurs we should re-throw the error as TskCoreException so that it is 
             logged by the calling method and move on to the next Solr document. */
-            throw new TskCoreException("Failed to create keyword hits for Solr documet id " + docId + " due to " + error.getMessage());
+            throw new TskCoreException("Failed to create keyword hits for Solr document id " + docId + " due to " + error.getMessage());
         }
         return hits;
     }


### PR DESCRIPTION
* Added a "catch" for all Throwbles and re-throwing as TskCoreException
* Logging those as SEVERE and moving on to next Solr document returned by the query