### PR TITLE
Minor AIM system log changes (2966)

### DIFF
--- a/Experimental/src/org/sleuthkit/autopsy/experimental/autoingest/AutoIngestManager.java
+++ b/Experimental/src/org/sleuthkit/autopsy/experimental/autoingest/AutoIngestManager.java
@@ -2646,8 +2646,6 @@ public final class AutoIngestManager extends Observable implements PropertyChang
                          * back into hostNamesToRunningJobs as a result of
                          * processing the job status update.
                          */
-                        SYS_LOGGER.log(Level.WARNING, "Auto ingest node {0} timed out while processing folder {1}",
-                                new Object[]{job.getNodeName(), job.getManifest().getFilePath().toString()});
                         hostNamesToRunningJobs.remove(job.getNodeName());
                         setChanged();
                         notifyObservers(Event.JOB_COMPLETED);

--- a/Experimental/src/org/sleuthkit/autopsy/experimental/autoingest/AutoIngestSystemLogger.java
+++ b/Experimental/src/org/sleuthkit/autopsy/experimental/autoingest/AutoIngestSystemLogger.java
@@ -35,7 +35,7 @@ import org.sleuthkit.autopsy.coreutils.PlatformUtil;
  */
 final class AutoIngestSystemLogger {
 
-    private static final int LOG_SIZE = 10000000; // In bytes, zero is unlimited, set to roughly 10mb currently
+    private static final int LOG_SIZE = 50000000; // In bytes, zero is unlimited, set to roughly 10mb currently
     private static final int LOG_FILE_COUNT = 10;
     private static final Logger LOGGER = Logger.getLogger("AutoIngest"); //NON-NLS
     private static final String NEWLINE = System.lineSeparator();


### PR DESCRIPTION
* Increased max log size to 50MB
* Removed a log entry that was deemed unnecessary 