### PR TITLE
Use name of "known" column to determine color instead of index

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/centralrepository/contentviewer/DataContentViewerOtherCasesTableCellRenderer.java
+++ b/Core/src/org/sleuthkit/autopsy/centralrepository/contentviewer/DataContentViewerOtherCasesTableCellRenderer.java
@@ -49,7 +49,8 @@ public class DataContentViewerOtherCasesTableCellRenderer implements TableCellRe
             foreground = Color.WHITE;
             background = Color.BLUE;
         } else {
-            String known_status = (String) table.getModel().getValueAt(row, 5);
+            String known_status = (String) table.getModel().getValueAt(row, 
+                    table.getColumn(DataContentViewerOtherCasesTableModel.TableColumns.KNOWN.columnName()).getModelIndex());
             if (known_status.equals(TskData.FileKnown.BAD.getName())) {
                     foreground = Color.WHITE;
                     background = Color.RED;

--- a/Core/src/org/sleuthkit/autopsy/centralrepository/contentviewer/DataContentViewerOtherCasesTableModel.java
+++ b/Core/src/org/sleuthkit/autopsy/centralrepository/contentviewer/DataContentViewerOtherCasesTableModel.java
@@ -40,9 +40,8 @@ public class DataContentViewerOtherCasesTableModel extends AbstractTableModel {
         "DataContentViewerOtherCasesTableModel.known=Known",
         "DataContentViewerOtherCasesTableModel.comment=Comment",
         "DataContentViewerOtherCasesTableModel.noData=No Data.",})
-    private enum TableColumns {
+    enum TableColumns {
         // Ordering here determines displayed column order in Content Viewer.
-        // If order is changed, update the CellRenderer to ensure correct row coloring.
         CASE_NAME(Bundle.DataContentViewerOtherCasesTableModel_case(), 75),
         DATA_SOURCE(Bundle.DataContentViewerOtherCasesTableModel_dataSource(), 75),
         TYPE(Bundle.DataContentViewerOtherCasesTableModel_type(), 40),


### PR DESCRIPTION
This fixes a bug that we were using the wrong column number for the known_status