### PR TITLE
Added check for pre-existing job in completed table.

### DIFF
--- a/Experimental/src/org/sleuthkit/autopsy/experimental/autoingest/AutoIngestManager.java
+++ b/Experimental/src/org/sleuthkit/autopsy/experimental/autoingest/AutoIngestManager.java
@@ -343,6 +343,10 @@ public final class AutoIngestManager extends Observable implements PropertyChang
         hostNamesToRunningJobs.remove(hostName);
         if (event.shouldRetry() == false) {
             synchronized (jobsLock) {
+                AutoIngestJob job = event.getJob();
+                if(completedJobs.contains(job)) {
+                    completedJobs.remove(job);
+                }
                 completedJobs.add(event.getJob());
             }
         }


### PR DESCRIPTION
Code checks for a pre-existing job, similar to how AutoIngestMonitor is currently doing it. Upon finding one, it replaces it. I'm not sure replacing it is necessary, but it's a 'safe' way to ensure we are using the absolute latest data in our completed jobs table.