### PR TITLE
Remove completion check from DataSourceIngestJob.cancel

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/ingest/DataSourceIngestJob.java
+++ b/Core/src/org/sleuthkit/autopsy/ingest/DataSourceIngestJob.java
@@ -1,7 +1,7 @@
 /*
  * Autopsy Forensic Browser
  *
- * Copyright 2011-2016 Basis Technology Corp.
+ * Copyright 2014-2017 Basis Technology Corp.
  * Contact: carrier <at> sleuthkit <dot> org
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -125,10 +125,9 @@ final class DataSourceIngestJob {
      * class.
      */
     private volatile boolean currentDataSourceIngestModuleCancelled;
+    private final List<String> cancelledDataSourceIngestModules = new CopyOnWriteArrayList<>();
     private volatile boolean cancelled;
     private volatile IngestJob.CancellationReason cancellationReason = IngestJob.CancellationReason.NOT_CANCELLED;
-    private final Object cancellationStateMonitor = new Object();
-    private final List<String> cancelledDataSourceIngestModules = new CopyOnWriteArrayList<>();
 
     /**
      * A data source ingest job uses the task scheduler singleton to create and
@@ -989,6 +988,10 @@ final class DataSourceIngestJob {
      * @param reason The cancellation reason.
      */
     void cancel(IngestJob.CancellationReason reason) {
+        this.cancelled = true;
+        this.cancellationReason = reason;
+        DataSourceIngestJob.taskScheduler.cancelPendingTasksForIngestJob(this);
+
         if (this.doUI) {
             /**
              * Put a cancellation message on data source level ingest progress
@@ -1023,32 +1026,9 @@ final class DataSourceIngestJob {
                                 "IngestJob.progress.fileIngest.cancelMessage",
                                 this.currentFileIngestModule, this.currentFileIngestTask));
                     }
-
                 }
             }
         }
-
-        /*
-         * If the work is not already done, show this job as cancelled for the
-         * given reason.
-         */
-        if (Stages.FINALIZATION != stage) {
-            synchronized (cancellationStateMonitor) {
-                /*
-                 * These fields are volatile for reading, synchronized on the
-                 * monitor here for writing.
-                 */
-                this.cancelled = true;
-                this.cancellationReason = reason;
-            }
-        }
-
-        /**
-         * Tell the task scheduler to cancel all pending tasks, i.e., tasks not
-         * not being performed by an ingest thread.
-         */
-        DataSourceIngestJob.taskScheduler.cancelPendingTasksForIngestJob(this);
-        this.checkForStageCompleted();
     }
 
     /**


### PR DESCRIPTION
This makes it so that the EDT will not block for the job completion check; the job completion checks will occur in the ingest threads. Note that a lock that was though to be needed to keep the volatile cancelled and cancellationReason fields was removed as actually unnecessary, and getting the cancellation action completed was prioritzed over getting the cancellation message written to the ingest progress bars.  

Also, the copyright for the file was corrected. 
