### PR TITLE
When looking for unalloc files, don't stop at first VirtualDirectory found.

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/directorytree/ExtractUnallocAction.java
+++ b/Core/src/org/sleuthkit/autopsy/directorytree/ExtractUnallocAction.java
@@ -454,13 +454,11 @@ final class ExtractUnallocAction extends AbstractAction {
         @Override
         public List<LayoutFile> visit(Directory dir) {
             try {
-                List<LayoutFile> results = new ArrayList<>();
                 for (Content c : dir.getChildren()) {
-                    if (c instanceof VirtualDirectory) {
-                        results.addAll(c.accept(this));
+                    if ((c instanceof VirtualDirectory) && (c.getName().equals(VirtualDirectory.NAME_UNALLOC))) {
+                        return c.accept(this);
                     }
                 }
-                return results;
             } catch (TskCoreException tce) {
                 logger.log(Level.WARNING, "Couldn't get a list of Unallocated Files, failed at visiting Directory " + dir.getId(), tce); //NON-NLS
             }

--- a/Core/src/org/sleuthkit/autopsy/directorytree/ExtractUnallocAction.java
+++ b/Core/src/org/sleuthkit/autopsy/directorytree/ExtractUnallocAction.java
@@ -147,7 +147,13 @@ final class ExtractUnallocAction extends AbstractAction {
                             uw.execute();
                         }
                     } else {
-                        logger.log(Level.WARNING, "Tried to get unallocated content from volume ID but " + u.VolumeId + u.llf == null ? "its list of unallocated files was null" : "the volume is locked"); //NON-NLS
+                        if(lockedVols.contains(u.getFileName())){
+                            logger.log(Level.WARNING, "Tried to get unallocated content but the volume is locked");  // NON_NLS
+                        } else if (u.llf == null){
+                            logger.log(Level.SEVERE, "Tried to get unallocated content but the list of unallocated files was null"); //NON-NLS
+                        } else {
+                            logger.log(Level.INFO, "No unallocated files found in volume"); //NON-NLS
+                        }
                     }
                 }
                 if (isImage && !copyList.isEmpty()) {
@@ -448,11 +454,13 @@ final class ExtractUnallocAction extends AbstractAction {
         @Override
         public List<LayoutFile> visit(Directory dir) {
             try {
+                List<LayoutFile> results = new ArrayList<>();
                 for (Content c : dir.getChildren()) {
                     if (c instanceof VirtualDirectory) {
-                        return c.accept(this);
+                        results.addAll(c.accept(this));
                     }
                 }
+                return results;
             } catch (TskCoreException tce) {
                 logger.log(Level.WARNING, "Couldn't get a list of Unallocated Files, failed at visiting Directory " + dir.getId(), tce); //NON-NLS
             }


### PR DESCRIPTION
Improve error messages.