### PR TITLE
3330 user conf file fix

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/corecomponents/AutopsyOptionsPanel.java
+++ b/Core/src/org/sleuthkit/autopsy/corecomponents/AutopsyOptionsPanel.java
@@ -458,7 +458,7 @@ final class AutopsyOptionsPanel extends javax.swing.JPanel {
             memFieldValidationLabel.setText(Bundle.AutopsyOptionsPanel_memFieldValidationLabel_underMinMemory_text(MIN_MEMORY_IN_GB));
             return false;
         }
-        if (parsedInt >= getSystemMemoryInGB()) {
+        if (parsedInt > getSystemMemoryInGB()) {
             memFieldValidationLabel.setText(Bundle.AutopsyOptionsPanel_memFieldValidationLabel_overMaxMemory_text(getSystemMemoryInGB()));
             return false;
         }

--- a/Core/src/org/sleuthkit/autopsy/corecomponents/AutopsyOptionsPanel.java
+++ b/Core/src/org/sleuthkit/autopsy/corecomponents/AutopsyOptionsPanel.java
@@ -206,10 +206,10 @@ final class AutopsyOptionsPanel extends javax.swing.JPanel {
      * @return the file which has the applications current .conf file
      */
     private static File getUserFolderConfFile() {
-        String confFileName = Version.getName() + CONFIG_FILE_EXTENSION;
+        String confFileName = UserPreferences.getAppName() + CONFIG_FILE_EXTENSION;
         File userFolder = PlatformUtil.getUserDirectory();
         File userEtcFolder = new File(userFolder, ETC_FOLDER_NAME);
-        if (!userEtcFolder.exists()) {
+        if (!userEtcFolder.exists()) {get
             userEtcFolder.mkdir();
         }
         return new File(userEtcFolder, confFileName);

--- a/Core/src/org/sleuthkit/autopsy/corecomponents/AutopsyOptionsPanel.java
+++ b/Core/src/org/sleuthkit/autopsy/corecomponents/AutopsyOptionsPanel.java
@@ -209,7 +209,7 @@ final class AutopsyOptionsPanel extends javax.swing.JPanel {
         String confFileName = UserPreferences.getAppName() + CONFIG_FILE_EXTENSION;
         File userFolder = PlatformUtil.getUserDirectory();
         File userEtcFolder = new File(userFolder, ETC_FOLDER_NAME);
-        if (!userEtcFolder.exists()) {get
+        if (!userEtcFolder.exists()) {
             userEtcFolder.mkdir();
         }
         return new File(userEtcFolder, confFileName);


### PR DESCRIPTION
Fixes to make this work as I had previously thought I had it working.

Correct Conf file is now written to User directory when modified .

Max memory a user can set can now be equal to the the system memory.