### PR TITLE
added setlookandfeel to AWT-EventQueue and made the font look consistent

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/corecomponents/Installer.java
+++ b/Core/src/org/sleuthkit/autopsy/corecomponents/Installer.java
@@ -18,11 +18,13 @@
  */
 package org.sleuthkit.autopsy.corecomponents;
 
+import java.awt.Font;
 import java.awt.Insets;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.logging.Level;
 import javax.swing.BorderFactory;
+import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.UIManager.LookAndFeelInfo;
 import javax.swing.UnsupportedLookAndFeelException;
@@ -56,7 +58,9 @@ public class Installer extends ModuleInstall {
     @Override
     public void restored() {
         super.restored();
-        setLookAndFeel();
+        SwingUtilities.invokeLater(() -> {
+            setLookAndFeel();  
+        });
         UIManager.put("ViewTabDisplayerUI", "org.sleuthkit.autopsy.corecomponents.NoTabsTabDisplayerUI");
         UIManager.put(DefaultTabbedContainerUI.KEY_VIEW_CONTENT_BORDER, BorderFactory.createEmptyBorder());
         UIManager.put("TabbedPane.contentBorderInsets", new Insets(0, 0, 0, 0));
@@ -69,7 +73,7 @@ public class Installer extends ModuleInstall {
     public void uninstalled() {
         super.uninstalled();
     }
-
+    
     private void setLookAndFeel() {
         if (System.getProperty("os.name").toLowerCase().contains("mac")) { //NON-NLS
             setOSXLookAndFeel();
@@ -88,7 +92,7 @@ public class Installer extends ModuleInstall {
             UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
         } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | UnsupportedLookAndFeelException ex) {
             logger.log(Level.WARNING, "Error setting OS-X look-and-feel", ex); //NON-NLS
-        }
+}
 
         // Store the keys that deal with menu items
         final String[] UI_MENU_ITEM_KEYS = new String[]{"MenuBarUI",}; //NON-NLS    
@@ -115,6 +119,16 @@ public class Installer extends ModuleInstall {
         });
     }
     
+    public static void setUIFont (javax.swing.plaf.FontUIResource f){
+    java.util.Enumeration keys = UIManager.getLookAndFeelDefaults().keys();
+    while (keys.hasMoreElements()) {
+      Object key = keys.nextElement();
+      Object value = UIManager.getLookAndFeelDefaults().get(key);
+      if (value instanceof javax.swing.plaf.FontUIResource)
+        UIManager.getLookAndFeelDefaults().put(key, f);
+      }
+    } 
+    
     private void setModuleSettings(String value) {
         if (ModuleSettings.configExists("timeline")) {
             ModuleSettings.setConfigSetting("timeline", "enable_timeline", value);
@@ -127,7 +141,8 @@ public class Installer extends ModuleInstall {
     private void setUnixLookAndFeel(){
         try {
             UIManager.put("swing.boldMetal", Boolean.FALSE);
-            UIManager.setLookAndFeel(UIManager.getCrossPlatformLookAndFeelClassName());
+            UIManager.setLookAndFeel("javax.swing.plaf.metal.MetalLookAndFeel");
+            setUIFont (new javax.swing.plaf.FontUIResource(Font.DIALOG,Font.PLAIN,11));
             setModuleSettings("true");
         } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | UnsupportedLookAndFeelException ex) {
             logger.log(Level.WARNING, "Error setting crossplatform look-and-feel, setting default look-and-feel",ex);


### PR DESCRIPTION
I named the metallookandfeel class explicitly in line 144 because UIManager.getCrossPlatformLookAndFeel might not be consistent on all distros. I wanted the LAF to be metal on  all linux distros as we planned.