### PR TITLE
3620 Use device ID instead of data source name in CorrelationAttributeInst…

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/centralrepository/datamodel/CorrelationAttributeInstance.java
+++ b/Core/src/org/sleuthkit/autopsy/centralrepository/datamodel/CorrelationAttributeInstance.java
@@ -111,7 +111,7 @@ public class CorrelationAttributeInstance implements Serializable {
     public String toString() {
         return this.getID()
                 + this.getCorrelationCase().getCaseUUID()
-                + this.getCorrelationDataSource().getName()
+                + this.getCorrelationDataSource().getDeviceID()
                 + this.getFilePath()
                 + this.getKnownStatus()
                 + this.getComment();


### PR DESCRIPTION
…ance.toString().
This will fix an issue where similar central repository artifacts were being discarded.