### PR TITLE
Fix merge error, updating getOpenCase to getCurrentCaseThrows

### DIFF
--- a/Core/test/qa-functional/src/org/sleuthkit/autopsy/modules/encryptiondetection/EncryptionDetectionTest.java
+++ b/Core/test/qa-functional/src/org/sleuthkit/autopsy/modules/encryptiondetection/EncryptionDetectionTest.java
@@ -77,7 +77,7 @@ public class EncryptionDetectionTest extends NbTestCase {
      */
     public void testPasswordProtection() {
         try {
-            Case openCase = Case.getOpenCase();
+            Case openCase = Case.getCurrentCaseThrows();
             
             /*
              * Create ingest job settings.


### PR DESCRIPTION
Fixes a probable merge mistake where getOpenCase was still being used in the a test method