### PR TITLE
modify intra-case queries to filter out single datasource results

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/commonfilesearch/AllDataSourcesCommonFilesAlgorithm.java
+++ b/Core/src/org/sleuthkit/autopsy/commonfilesearch/AllDataSourcesCommonFilesAlgorithm.java
@@ -20,13 +20,14 @@
 package org.sleuthkit.autopsy.commonfilesearch;
 
 import java.util.Map;
+import org.sleuthkit.datamodel.TskData.FileKnown;
 
 /**
  * Provides logic for selecting common files from all data sources.
  */
 final public class AllDataSourcesCommonFilesAlgorithm extends CommonFilesMetadataBuilder {
 
-    private static final String WHERE_CLAUSE = "%s md5 in (select md5 from tsk_files where (known != 1 OR known IS NULL)%s GROUP BY  md5 HAVING  COUNT(DISTINCT data_source_obj_id) > 1) order by md5"; //NON-NLS
+    private static final String WHERE_CLAUSE = "%s md5 in (select md5 from tsk_files where (known != "+ FileKnown.KNOWN + " OR known IS NULL)%s GROUP BY  md5 HAVING  COUNT(DISTINCT data_source_obj_id) > 1) order by md5"; //NON-NLS
 
     /**
      * Implements the algorithm for getting common files across all data

--- a/Core/src/org/sleuthkit/autopsy/commonfilesearch/AllDataSourcesCommonFilesAlgorithm.java
+++ b/Core/src/org/sleuthkit/autopsy/commonfilesearch/AllDataSourcesCommonFilesAlgorithm.java
@@ -26,7 +26,7 @@ import java.util.Map;
  */
 final public class AllDataSourcesCommonFilesAlgorithm extends CommonFilesMetadataBuilder {
 
-    private static final String WHERE_CLAUSE = "%s md5 in (select md5 from tsk_files where (known != 1 OR known IS NULL)%s GROUP BY  md5 HAVING  COUNT(*) > 1) order by md5"; //NON-NLS
+    private static final String WHERE_CLAUSE = "%s md5 in (select md5 from tsk_files where (known != 1 OR known IS NULL)%s GROUP BY  md5 HAVING  COUNT(DISTINCT data_source_obj_id) > 1) order by md5"; //NON-NLS
 
     /**
      * Implements the algorithm for getting common files across all data

--- a/Core/src/org/sleuthkit/autopsy/commonfilesearch/SingleDataSource.java
+++ b/Core/src/org/sleuthkit/autopsy/commonfilesearch/SingleDataSource.java
@@ -20,13 +20,14 @@
 package org.sleuthkit.autopsy.commonfilesearch;
 
 import java.util.Map;
+import org.sleuthkit.datamodel.TskData.FileKnown;
 
 /**
  * Provides logic for selecting common files from a single data source.
  */
 final public class SingleDataSource extends CommonFilesMetadataBuilder {
 
-    private static final String WHERE_CLAUSE = "%s md5 in (select md5 from tsk_files where md5 in (select md5 from tsk_files where (known != 1 OR known IS NULL) and data_source_obj_id=%s%s) GROUP BY md5 HAVING COUNT(DISTINCT data_source_obj_id) > 1) order by md5"; //NON-NLS
+    private static final String WHERE_CLAUSE = "%s md5 in (select md5 from tsk_files where md5 in (select md5 from tsk_files where (known != "+ FileKnown.KNOWN + " OR known IS NULL) and data_source_obj_id=%s%s) GROUP BY md5 HAVING COUNT(DISTINCT data_source_obj_id) > 1) order by md5"; //NON-NLS
     private final Long selectedDataSourceId;
     private final String dataSourceName;
 

--- a/Core/src/org/sleuthkit/autopsy/commonfilesearch/SingleDataSource.java
+++ b/Core/src/org/sleuthkit/autopsy/commonfilesearch/SingleDataSource.java
@@ -26,7 +26,7 @@ import java.util.Map;
  */
 final public class SingleDataSource extends CommonFilesMetadataBuilder {
 
-    private static final String WHERE_CLAUSE = "%s md5 in (select md5 from tsk_files where md5 in (select md5 from tsk_files where (known != 1 OR known IS NULL) and data_source_obj_id=%s%s) GROUP BY md5 HAVING COUNT(*) > 1) order by md5"; //NON-NLS
+    private static final String WHERE_CLAUSE = "%s md5 in (select md5 from tsk_files where md5 in (select md5 from tsk_files where (known != 1 OR known IS NULL) and data_source_obj_id=%s%s) GROUP BY md5 HAVING COUNT(DISTINCT data_source_obj_id) > 1) order by md5"; //NON-NLS
     private final Long selectedDataSourceId;
     private final String dataSourceName;
 


### PR DESCRIPTION
 No longer returns matching md5s that exist only within a single datasource.