### PR TITLE
Don't try to add new data sources to the central repo twice.

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/centralrepository/datamodel/AbstractSqlEamDb.java
+++ b/Core/src/org/sleuthkit/autopsy/centralrepository/datamodel/AbstractSqlEamDb.java
@@ -432,7 +432,8 @@ abstract class AbstractSqlEamDb implements EamDb {
         if (eamDataSource.getCaseID() == -1) {
             throw new EamDbException("Case ID is -1");
         } else if (eamDataSource.getID() != -1) {
-            throw new EamDbException("Database ID is already set in object");
+            // This data source is already in the central repo
+            return;
         }
         Connection conn = connect();
 

--- a/Core/src/org/sleuthkit/autopsy/centralrepository/datamodel/CorrelationDataSource.java
+++ b/Core/src/org/sleuthkit/autopsy/centralrepository/datamodel/CorrelationDataSource.java
@@ -67,6 +67,7 @@ public class CorrelationDataSource implements Serializable {
 
     /**
      * Create a CorrelationDataSource object from a TSK Content object.
+     * This will add it to the central repository.
      *
      * @param correlationCase the current CorrelationCase used for ensuring
      *                        uniqueness of DataSource

--- a/Core/src/org/sleuthkit/autopsy/centralrepository/eventlisteners/CaseEventListener.java
+++ b/Core/src/org/sleuthkit/autopsy/centralrepository/eventlisteners/CaseEventListener.java
@@ -450,10 +450,10 @@ final class CaseEventListener implements PropertyChangeListener {
                     correlationCase = dbManager.newCase(openCase);
                 }
                 if (null == dbManager.getDataSource(correlationCase, deviceId)) {
-                    dbManager.newDataSource(CorrelationDataSource.fromTSKDataSource(correlationCase, newDataSource));
+                    CorrelationDataSource.fromTSKDataSource(correlationCase, newDataSource);
                 }
             } catch (EamDbException ex) {
-                LOGGER.log(Level.SEVERE, "Error connecting to Central Repository database.", ex); //NON-NLS
+                LOGGER.log(Level.SEVERE, "Error adding new data source to the central repository", ex); //NON-NLS
             } catch (TskCoreException | TskDataException ex) {
                 LOGGER.log(Level.SEVERE, "Error getting data source from DATA_SOURCE_ADDED event content.", ex); //NON-NLS
             }


### PR DESCRIPTION
Don't throw an exception when attempting to add an already initialized data source