### PR TITLE
modified mac os X install docs

### DIFF
--- a/Running_Linux_OSX.txt
+++ b/Running_Linux_OSX.txt
@@ -25,7 +25,7 @@ Autopsy depends on a specific version of The Sleuth Kit.  You need the Java libr
 -- % sudo apt install ./sleuthkit-java_4.6.0-1_amd64.deb
 
 - OS X: Install The Sleuth Kit from brew.  
--- % brew install sleuthkit --with-jni --with-libewf --with-afflib
+-- % brew install sleuthkit
 
 
 * Install Autopsy *


### PR DESCRIPTION
Homebrew people have updated the sleuthkit installation process to our liking. Users of Autopsy in Mac OSX do not have to use --with-jni bindings during installation. Java bindings with be installed automatically.