### PR TITLE
Modify tests to use appropriate method signature for AbstractCommonAttributeSearcher

### DIFF
--- a/Core/test/qa-functional/src/org/sleuthkit/autopsy/commonfilessearch/CommonAttributeSearchInterCaseTests.java
+++ b/Core/test/qa-functional/src/org/sleuthkit/autopsy/commonfilessearch/CommonAttributeSearchInterCaseTests.java
@@ -21,7 +21,6 @@ package org.sleuthkit.autopsy.commonfilessearch;
 
 import java.nio.file.Path;
 import java.sql.SQLException;
-import java.util.Map;
 import junit.framework.Assert;
 import junit.framework.Test;
 import org.netbeans.junit.NbModuleSuite;
@@ -111,9 +110,8 @@ public class CommonAttributeSearchInterCaseTests extends NbTestCase {
     private void assertResultsAreOfType(CorrelationAttributeInstance.Type type) {
 
         try {
-            Map<Long, String> dataSources = this.utils.getDataSourceMap();
 
-            AbstractCommonAttributeSearcher builder = new AllInterCaseCommonAttributeSearcher(dataSources, false, false, type, 0);
+            AbstractCommonAttributeSearcher builder = new AllInterCaseCommonAttributeSearcher(false, false, type, 0);
 
             CommonAttributeSearchResults metadata = builder.findMatches();
 
@@ -146,22 +144,21 @@ public class CommonAttributeSearchInterCaseTests extends NbTestCase {
      */
     public void testTwo() {
         try {
-            Map<Long, String> dataSources = this.utils.getDataSourceMap();
 
             AbstractCommonAttributeSearcher builder;
             CommonAttributeSearchResults metadata;
 
-            builder = new AllInterCaseCommonAttributeSearcher(dataSources, false, false, this.utils.USB_ID_TYPE, 100);
+            builder = new AllInterCaseCommonAttributeSearcher(false, false, this.utils.USB_ID_TYPE, 100);
             metadata = builder.findMatches();
             metadata.size();
             //assertTrue("This should yield 13 results.", verifyInstanceCount(metadata, 13));
 
-            builder = new AllInterCaseCommonAttributeSearcher(dataSources, false, false, this.utils.USB_ID_TYPE, 20);
+            builder = new AllInterCaseCommonAttributeSearcher(false, false, this.utils.USB_ID_TYPE, 20);
             metadata = builder.findMatches();
             metadata.size();
             //assertTrue("This should yield no results.", verifyInstanceCount(metadata, 0));
 
-            builder = new AllInterCaseCommonAttributeSearcher(dataSources, false, false, this.utils.USB_ID_TYPE, 90);
+            builder = new AllInterCaseCommonAttributeSearcher(false, false, this.utils.USB_ID_TYPE, 90);
             metadata = builder.findMatches();
             metadata.size();
             //assertTrue("This should yield 2 results.", verifyInstanceCount(metadata, 2));

--- a/Core/test/qa-functional/src/org/sleuthkit/autopsy/commonfilessearch/IngestedWithHashAndFileTypeInterCaseTests.java
+++ b/Core/test/qa-functional/src/org/sleuthkit/autopsy/commonfilessearch/IngestedWithHashAndFileTypeInterCaseTests.java
@@ -21,7 +21,6 @@ package org.sleuthkit.autopsy.commonfilessearch;
 
 import java.nio.file.Path;
 import java.sql.SQLException;
-import java.util.Map;
 import junit.framework.Test;
 import org.netbeans.junit.NbModuleSuite;
 import org.netbeans.junit.NbTestCase;
@@ -96,10 +95,8 @@ public class IngestedWithHashAndFileTypeInterCaseTests extends NbTestCase {
      */
     public void testOne() {
         try {
-            Map<Long, String> dataSources = this.utils.getDataSourceMap();
-
             //note that the params false and false are presently meaningless because that feature is not supported yet
-            AbstractCommonAttributeSearcher builder = new AllInterCaseCommonAttributeSearcher(dataSources, false, false, this.utils.FILE_TYPE, 0);
+            AbstractCommonAttributeSearcher builder = new AllInterCaseCommonAttributeSearcher(false, false, this.utils.FILE_TYPE, 0);
             CommonAttributeSearchResults metadata = builder.findMatches();
 
             assertTrue("Results should not be empty", metadata.size() != 0);
@@ -146,11 +143,10 @@ public class IngestedWithHashAndFileTypeInterCaseTests extends NbTestCase {
      */
     public void testTwo() {
         try {
-            Map<Long, String> dataSources = this.utils.getDataSourceMap();
 
             int matchesMustAlsoBeFoundInThisCase = this.utils.getCaseMap().get(CASE2);
             CorrelationAttributeInstance.Type fileType = CorrelationAttributeInstance.getDefaultCorrelationTypes().get(0);
-            AbstractCommonAttributeSearcher builder = new SingleInterCaseCommonAttributeSearcher(matchesMustAlsoBeFoundInThisCase, dataSources, false, false, fileType, 0);
+            AbstractCommonAttributeSearcher builder = new SingleInterCaseCommonAttributeSearcher(matchesMustAlsoBeFoundInThisCase, false, false, fileType, 0);
             
             CommonAttributeSearchResults metadata = builder.findMatches();
 
@@ -199,11 +195,10 @@ public class IngestedWithHashAndFileTypeInterCaseTests extends NbTestCase {
      */
     public void testThree(){
         try {
-            Map<Long, String> dataSources = this.utils.getDataSourceMap();
             
             //note that the params false and false are presently meaningless because that feature is not supported yet
             CorrelationAttributeInstance.Type fileType = CorrelationAttributeInstance.getDefaultCorrelationTypes().get(0);
-            AbstractCommonAttributeSearcher builder = new AllInterCaseCommonAttributeSearcher(dataSources, false, false, fileType, 50);
+            AbstractCommonAttributeSearcher builder = new AllInterCaseCommonAttributeSearcher(false, false, fileType, 50);
             
             CommonAttributeSearchResults metadata = builder.findMatches();
             


### PR DESCRIPTION
Allow test classes to build.