### PR TITLE
1050 IG Groups UI fixes

### DIFF
--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/actions/NextUnseenGroup.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/actions/NextUnseenGroup.java
@@ -72,6 +72,7 @@ public class NextUnseenGroup extends Action {
             Optional.ofNullable(controller.getViewState())
                     .flatMap(GroupViewState::getGroup)
                     .ifPresent(group -> {
+                        setDisabled(true);
                         groupManager.markGroupSeen(group, true)
                                 .addListener(this::advanceToNextUnseenGroup, MoreExecutors.newDirectExecutorService());
                     });


### PR DESCRIPTION
minimal feed back while changing groups: disable the next unseen group button.