### PR TITLE
Add Statement so ignore loading job settings of Python modules

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/ingest/IngestJobSettings.java
+++ b/Core/src/org/sleuthkit/autopsy/ingest/IngestJobSettings.java
@@ -491,12 +491,14 @@ public final class IngestJobSettings {
         String moduleSettingsFilePath = getModuleSettingsFilePath(factory);
         File settingsFile = new File(moduleSettingsFilePath);
         if (settingsFile.exists()) {
-            try (NbObjectInputStream in = new NbObjectInputStream(new FileInputStream(settingsFile.getAbsolutePath()))) {
-                settings = (IngestModuleIngestJobSettings) in.readObject();
-            } catch (IOException | ClassNotFoundException ex) {
-                String warning = NbBundle.getMessage(IngestJobSettings.class, "IngestJobSettings.moduleSettingsLoad.warning", factory.getModuleDisplayName(), this.executionContext); //NON-NLS                 
-                logger.log(Level.WARNING, warning, ex);
-                this.warnings.add(warning);
+            if (!isPythonModuleSettingsFile(moduleSettingsFilePath)) {
+                try (NbObjectInputStream in = new NbObjectInputStream(new FileInputStream(settingsFile.getAbsolutePath()))) {
+                    settings = (IngestModuleIngestJobSettings) in.readObject();
+                } catch (IOException | ClassNotFoundException ex) {
+                    String warning = NbBundle.getMessage(IngestJobSettings.class, "IngestJobSettings.moduleSettingsLoad.warning", factory.getModuleDisplayName(), this.executionContext); //NON-NLS                 
+                    logger.log(Level.WARNING, warning, ex);
+                    this.warnings.add(warning);
+                }
             }
         }
         if (settings == null) {


### PR DESCRIPTION
Add an if statement to ignore the loading of the job settings for python modules that were stored and load the default settings.  Serilization is not working for Python job settings for some reason.  This will make sure users do not get unneeded messages.