### PR TITLE
4556 fix bug in upgrade population of CR data source obj id

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/centralrepository/datamodel/DataSourceUpdateService.java
+++ b/Core/src/org/sleuthkit/autopsy/centralrepository/datamodel/DataSourceUpdateService.java
@@ -51,7 +51,7 @@ public class DataSourceUpdateService implements AutopsyService {
                         //ResultSet.getLong has a value of 0 when the value is null
                         if (correlationDataSource.getCaseID() == correlationCase.getID() && correlationDataSource.getDataSourceObjectID() == 0) {
                             for (Content dataSource : context.getCase().getDataSources()) {
-                                if (((DataSource) dataSource).getDeviceId().equals(correlationDataSource.getDeviceID())) {
+                                if (((DataSource) dataSource).getDeviceId().equals(correlationDataSource.getDeviceID()) && dataSource.getName().equals(correlationDataSource.getName())) {
                                     centralRepository.addDataSourceObjectId(correlationDataSource.getID(), dataSource.getId());
                                     break;
                                 }


### PR DESCRIPTION
Addresses bug found in upgrade population of data source object id observed by @rcordovano while working on 4556

This change will add a comparison for name of datasource before assigning a data source object id so that in the situation where a data source has the same case and device id as another data source but a different data source name it will assign a correct data source object id