### PR TITLE
Changed from asychronous to synchronous child creation since the keys…

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/commonfilesearch/CommonAttributeCountSearchResults.java
+++ b/Core/src/org/sleuthkit/autopsy/commonfilesearch/CommonAttributeCountSearchResults.java
@@ -130,6 +130,10 @@ final public class CommonAttributeCountSearchResults {
      * @return metadata
      */
     private void filterMetadata(int maximumPercentageThreshold) throws EamDbException {
+        if (!EamDb.isEnabled()) {
+            return;
+        }
+
         CorrelationAttributeInstance.Type attributeType = CorrelationAttributeInstance
                 .getDefaultCorrelationTypes()
                 .stream()

--- a/Core/src/org/sleuthkit/autopsy/commonfilesearch/InstanceCountNode.java
+++ b/Core/src/org/sleuthkit/autopsy/commonfilesearch/InstanceCountNode.java
@@ -57,7 +57,7 @@ public final class InstanceCountNode extends DisplayableItemNode {
         "InstanceCountNode.displayName=Files with %s instances (%s)"
     })
     public InstanceCountNode(int instanceCount, CommonAttributeValueList attributeValues) {
-        super(Children.create(new CommonAttributeValueNodeFactory(attributeValues.getMetadataList()), true));
+        super(Children.create(new CommonAttributeValueNodeFactory(attributeValues.getMetadataList()), false));
 
         this.instanceCount = instanceCount;
         this.attributeValues = attributeValues;
@@ -81,7 +81,7 @@ public final class InstanceCountNode extends DisplayableItemNode {
      */
     void createChildren() {
         attributeValues.displayDelayedMetadata();
-        setChildren(Children.create(new CommonAttributeValueNodeFactory(attributeValues.getMetadataList()), true));
+        setChildren(Children.create(new CommonAttributeValueNodeFactory(attributeValues.getMetadataList()), false));
     }
 
     /**


### PR DESCRIPTION
… are already being created on a separate worker thread. This change mitigates the issue where a wait node was being displayed and not going away.