### PR TITLE
Optimization and Bug fix - Make Tika use AbstractFile mimetype instead of recomputing

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/textextractors/TikaTextExtractor.java
+++ b/Core/src/org/sleuthkit/autopsy/textextractors/TikaTextExtractor.java
@@ -50,7 +50,6 @@ import org.apache.tika.parser.ParsingReader;
 import org.apache.tika.parser.microsoft.OfficeParserConfig;
 import org.apache.tika.parser.ocr.TesseractOCRConfig;
 import org.apache.tika.parser.pdf.PDFParserConfig;
-import org.apache.tika.detect.Detector;
 import org.apache.tika.mime.MediaType;
 import org.openide.util.NbBundle;
 import org.openide.modules.InstalledFileLocator;

--- a/Core/src/org/sleuthkit/autopsy/textextractors/TikaTextExtractor.java
+++ b/Core/src/org/sleuthkit/autopsy/textextractors/TikaTextExtractor.java
@@ -152,7 +152,7 @@ final class TikaTextExtractor implements TextExtractor {
 
         if (content instanceof AbstractFile) {
             AbstractFile file = (AbstractFile) content;
-            if (file.getMIMEType() != null) {
+            if (file.getMIMEType() != null && !file.getMIMEType().isEmpty()) {
                 //Force Tika to use our pre-computed mime type during detection
                 parser.setDetector((InputStream inStream, Metadata metaData)
                         -> MediaType.parse(file.getMIMEType()));

--- a/Core/src/org/sleuthkit/autopsy/textextractors/TikaTextExtractor.java
+++ b/Core/src/org/sleuthkit/autopsy/textextractors/TikaTextExtractor.java
@@ -127,7 +127,7 @@ final class TikaTextExtractor implements TextExtractor {
     private final ExecutorService executorService = Executors.newSingleThreadExecutor(tikaThreadFactory);
     private static final String SQLITE_MIMETYPE = "application/x-sqlite3";
 
-    private AutoDetectParser parser;
+    private final AutoDetectParser parser;
     private final Content content;
 
     private boolean tesseractOCREnabled;

--- a/Core/src/org/sleuthkit/autopsy/textextractors/TikaTextExtractor.java
+++ b/Core/src/org/sleuthkit/autopsy/textextractors/TikaTextExtractor.java
@@ -153,7 +153,7 @@ final class TikaTextExtractor implements TextExtractor {
         if (content instanceof AbstractFile) {
             AbstractFile file = (AbstractFile) content;
             if(file.getMIMEType() != null) {
-                //Set the Tika logic to use the pre-computed mime type
+                //Force Tika to use our pre-computed mime type during detection
                 parser.setDetector((InputStream inStream, Metadata metaData) -> 
                         MediaType.parse(file.getMIMEType()));
             }

--- a/Core/src/org/sleuthkit/autopsy/textextractors/TikaTextExtractor.java
+++ b/Core/src/org/sleuthkit/autopsy/textextractors/TikaTextExtractor.java
@@ -147,25 +147,16 @@ final class TikaTextExtractor implements TextExtractor {
 
     public TikaTextExtractor(Content content) {
         this.content = content;
+        
+        parser = new AutoDetectParser();
 
-        if (!(content instanceof AbstractFile)) {
-            parser = new AutoDetectParser();
-            return;
-        }
-
-        AbstractFile file = (AbstractFile) content;
-        if (file.getMIMEType() == null) {
-            parser = new AutoDetectParser();
-        } else {
-            parser = new AutoDetectParser(new Detector() {
-                /**
-                 * Set the Tika logic to use the pre-computed mime type
-                 */
-                @Override
-                public MediaType detect(InputStream in, Metadata mtdt) throws IOException {
-                    return MediaType.parse(file.getMIMEType());
-                }
-            });
+        if (content instanceof AbstractFile) {
+            AbstractFile file = (AbstractFile) content;
+            if(file.getMIMEType() != null) {
+                //Set the Tika logic to use the pre-computed mime type
+                parser.setDetector((InputStream inStream, Metadata metaData) -> 
+                        MediaType.parse(file.getMIMEType()));
+            }
         }
     }
 

--- a/Core/src/org/sleuthkit/autopsy/textextractors/TikaTextExtractor.java
+++ b/Core/src/org/sleuthkit/autopsy/textextractors/TikaTextExtractor.java
@@ -147,15 +147,15 @@ final class TikaTextExtractor implements TextExtractor {
 
     public TikaTextExtractor(Content content) {
         this.content = content;
-        
+
         parser = new AutoDetectParser();
 
         if (content instanceof AbstractFile) {
             AbstractFile file = (AbstractFile) content;
-            if(file.getMIMEType() != null) {
+            if (file.getMIMEType() != null) {
                 //Force Tika to use our pre-computed mime type during detection
-                parser.setDetector((InputStream inStream, Metadata metaData) -> 
-                        MediaType.parse(file.getMIMEType()));
+                parser.setDetector((InputStream inStream, Metadata metaData)
+                        -> MediaType.parse(file.getMIMEType()));
             }
         }
     }


### PR DESCRIPTION
This is esp critical if we override the mimetype ourselves. We also gain a noticeable performance boost.