### PR TITLE
5071 Strings CV missing characters

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/coreutils/StringExtract.java
+++ b/Core/src/org/sleuthkit/autopsy/coreutils/StringExtract.java
@@ -221,7 +221,8 @@ public class StringExtract {
             StringExtractResult resWin = null;
             if (enableUTF8 && resUTF16 != null) {
                 resWin = runUTF16 && resUTF16.numChars > resUTF8.numChars ? resUTF16 : resUTF8;
-            } else if (enableUTF16) {
+            } else if (runUTF16) {
+                //Only let resUTF16 "win" if it was actually run.
                 resWin = resUTF16;
             } else if (enableUTF8) {
                 resWin = resUTF8;


### PR DESCRIPTION
When UTF-16 extraction is enabled and produces no result (on odd offsets), the null value would always win and the offset would be incremented by 1. Now, with the offset being even, UTF-16 extraction produced a non-null result... but we completely skipped a character. Changing the flag to accept only if UTF16 was actually run resolved this story.

Edit: It is worth mentioning that on this odd offset, UTF-8 contained the correct result and should have won. The change in this PR allows UTF8 the opportunity to win.