### PR TITLE
2428 - Registry file viewer does not display content for all registry files

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/contentviewers/FileViewer.java
+++ b/Core/src/org/sleuthkit/autopsy/contentviewers/FileViewer.java
@@ -143,7 +143,7 @@ public class FileViewer extends javax.swing.JPanel implements DataContentViewer 
                 viewer.setFile(file);
                 this.removeAll();
                 this.add(viewer.getComponent());
-                this.repaint();
+                this.validate();
             }
         }
 


### PR DESCRIPTION
Add validate to replace paint to show registry tree every time a registry file is selected.