### PR TITLE
5323 Use result object instead of hash map.

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/filequery/FileSearch.java
+++ b/Core/src/org/sleuthkit/autopsy/filequery/FileSearch.java
@@ -95,8 +95,8 @@ class FileSearch {
         SearchResults searchResults = new SearchResults(groupSortingType, groupAttributeType, fileSortingMethod);
         searchResults.add(resultFiles);
 
-        // We don't need the linked hash map, but this also does the sorting and grouping
-        searchResults.toLinkedHashMap();
+        // Sort and group the results
+        searchResults.sortGroupsAndFiles();
 
         return searchResults;
     }

--- a/Core/src/org/sleuthkit/autopsy/filequery/FileSearchPanel.java
+++ b/Core/src/org/sleuthkit/autopsy/filequery/FileSearchPanel.java
@@ -1218,6 +1218,7 @@ final class FileSearchPanel extends javax.swing.JPanel implements ActionListener
                 searchTerm = new ParentSearchTerm(parentTextField.getText(), false);
             }
             parentListModel.add(parentListModel.size(), searchTerm);
+            validateFields();
         }
     }//GEN-LAST:event_addButtonActionPerformed
 
@@ -1230,6 +1231,7 @@ final class FileSearchPanel extends javax.swing.JPanel implements ActionListener
     private void deleteButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_deleteButtonActionPerformed
         int index = parentList.getSelectedIndex();
         parentListModel.remove(index);
+        validateFields();
     }//GEN-LAST:event_deleteButtonActionPerformed
 
     private void parentListValueChanged(javax.swing.event.ListSelectionEvent evt) {//GEN-FIRST:event_parentListValueChanged

--- a/Core/src/org/sleuthkit/autopsy/filequery/GroupListPanel.java
+++ b/Core/src/org/sleuthkit/autopsy/filequery/GroupListPanel.java
@@ -34,7 +34,7 @@ class GroupListPanel extends javax.swing.JPanel {
 
     private final static Logger logger = Logger.getLogger(GroupListPanel.class.getName());
     private static final long serialVersionUID = 1L;
-    private LinkedHashMap<String, List<AbstractFile>> results = null;
+    private SearchResults results = null;
     private FileType resultType = null;
 
     /**
@@ -52,7 +52,7 @@ class GroupListPanel extends javax.swing.JPanel {
     @Subscribe
     void handleSearchStartedEvent(DiscoveryEvents.SearchStartedEvent searchStartedEvent) {
         resultType = searchStartedEvent.getType();
-        results = new LinkedHashMap<>();
+        results = new SearchResults();
         groupList.setListData(new String[0]);
     }
 
@@ -64,19 +64,15 @@ class GroupListPanel extends javax.swing.JPanel {
      */
     @Subscribe
     void handleSearchCompleteEvent(DiscoveryEvents.SearchCompleteEvent searchCompleteEvent) {
-        try {
-            results = searchCompleteEvent.getSearchResults().toLinkedHashMap();
-            Set<String> resultsKeySet = results.keySet();
-            groupList.setListData(resultsKeySet.toArray(new String[results.size()]));
-            if (groupList.getModel().getSize() > 0) {
-                groupList.setSelectedIndex(0);
-            }
-            validate();
-            repaint();
-        } catch (FileSearchException ex) {
-            logger.log(Level.WARNING, "Error handling completed search results for file discovery, no results displayed", ex);
-            groupList.setListData(new String[0]);
+
+        results = searchCompleteEvent.getSearchResults();
+        List<String> groupNames = results.getGroupNamesWithCounts();
+        groupList.setListData(groupNames.toArray(new String[groupNames.size()]));
+        if (groupList.getModel().getSize() > 0) {
+            groupList.setSelectedIndex(0);
         }
+        validate();
+        repaint();
     }
 
     /**
@@ -122,7 +118,7 @@ class GroupListPanel extends javax.swing.JPanel {
      */
     private void groupSelected(javax.swing.event.ListSelectionEvent evt) {//GEN-FIRST:event_groupSelected
         if (!evt.getValueIsAdjusting() && results != null) {
-            DiscoveryEvents.getDiscoveryEventBus().post(new DiscoveryEvents.GroupSelectedEvent(resultType, results.get(groupList.getSelectedValue())));
+            DiscoveryEvents.getDiscoveryEventBus().post(new DiscoveryEvents.GroupSelectedEvent(resultType, results.getAbstractFilesInGroup(groupList.getSelectedValue())));
         }
     }//GEN-LAST:event_groupSelected
 


### PR DESCRIPTION
Display group sizes again.
Fixed bug with parent path enabling.