### PR TITLE
5352 CR frequency fixes/only count cases

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/filequery/FileSearch.java
+++ b/Core/src/org/sleuthkit/autopsy/filequery/FileSearch.java
@@ -843,7 +843,7 @@ class FileSearch {
             String tableName = EamDbUtil.correlationTypeToInstanceTableName(attributeType);
             
             String selectClause = " value, COUNT(value) FROM "
-                    + "(SELECT DISTINCT case_id, data_source_id, value FROM " + tableName
+                    + "(SELECT DISTINCT case_id, value FROM " + tableName
                     + " WHERE value IN ("
                     + hashes
                     + ")) AS foo GROUP BY value";

--- a/Core/src/org/sleuthkit/autopsy/filequery/FileSearch.java
+++ b/Core/src/org/sleuthkit/autopsy/filequery/FileSearch.java
@@ -866,13 +866,13 @@ class FileSearch {
         private final List<ResultFile> files;
 
         private FrequencyCallback(List<ResultFile> files) {
-            this.files = files;
+            this.files = new ArrayList<>(files);
         }
 
         @Override
         public void process(ResultSet resultSet) {
             try {
-
+                
                 while (resultSet.next()) {
                     String hash = resultSet.getString(1);
                     int count = resultSet.getInt(2);
@@ -883,6 +883,11 @@ class FileSearch {
                             iterator.remove();
                         }
                     }
+                }
+                
+                // The files left had no matching entries in the CR, so mark them as unique
+                for (ResultFile file : files) {
+                    file.setFrequency(Frequency.UNIQUE);
                 }
             } catch (SQLException ex) {
                 logger.log(Level.WARNING, "Error getting frequency counts from Central Repository", ex); // NON-NLS

--- a/Core/src/org/sleuthkit/autopsy/filequery/FileSearchData.java
+++ b/Core/src/org/sleuthkit/autopsy/filequery/FileSearchData.java
@@ -46,12 +46,12 @@ class FileSearchData {
     enum Frequency {
 	UNIQUE(0, 1, Bundle.FileSearchData_Frequency_unique_displayName()),
 	RARE(1, 5, Bundle.FileSearchData_Frequency_rare_displayName()),
-	COUNT_10(1, 10, Bundle.FileSearchData_Frequency_count_10_displayName()),
-	COUNT_20(1, 10, Bundle.FileSearchData_Frequency_count_20_displayName()),
-	COUNT_50(1, 10, Bundle.FileSearchData_Frequency_count_50_displayName()),
-	COUNT_100(1, 10, Bundle.FileSearchData_Frequency_count_100_displayName()),
-	COMMON(2, 0, Bundle.FileSearchData_Frequency_common_displayName()),
-	UNKNOWN(3, 0, Bundle.FileSearchData_Frequency_unknown_displayName());
+	COUNT_10(2, 10, Bundle.FileSearchData_Frequency_count_10_displayName()),
+	COUNT_20(3, 20, Bundle.FileSearchData_Frequency_count_20_displayName()),
+	COUNT_50(4, 50, Bundle.FileSearchData_Frequency_count_50_displayName()),
+	COUNT_100(5, 100, Bundle.FileSearchData_Frequency_count_100_displayName()),
+	COMMON(6, 0, Bundle.FileSearchData_Frequency_common_displayName()),
+	UNKNOWN(7, 0, Bundle.FileSearchData_Frequency_unknown_displayName());
         
         private final int ranking;
         private final String displayName;


### PR DESCRIPTION
Mark files with no matches as UNIQUE.
Fix the CR enums.
Count cases for frequency instead of data sources