### PR TITLE
Rename test files to end with "Test"

### DIFF
--- a/Core/test/qa-functional/src/org/sleuthkit/autopsy/commonpropertiessearch/CommonAttributeSearchInterCaseTest.java
+++ b/Core/test/qa-functional/src/org/sleuthkit/autopsy/commonpropertiessearch/CommonAttributeSearchInterCaseTest.java
@@ -51,18 +51,18 @@ import org.sleuthkit.datamodel.TskCoreException;
  * publicly exposing the keyword search module settings fails due to a circular
  * dependency.
  */
-public class CommonAttributeSearchInterCaseTests extends NbTestCase {
+public class CommonAttributeSearchInterCaseTest extends NbTestCase {
 
     private final InterCaseTestUtils utils;
 
     public static Test suite() {
-        NbModuleSuite.Configuration conf = NbModuleSuite.createConfiguration(CommonAttributeSearchInterCaseTests.class).
+        NbModuleSuite.Configuration conf = NbModuleSuite.createConfiguration(CommonAttributeSearchInterCaseTest.class).
                 clusters(".*").
                 enableModules(".*");
         return conf.suite();
     }
 
-    public CommonAttributeSearchInterCaseTests(String name) {
+    public CommonAttributeSearchInterCaseTest(String name) {
         super(name);
         this.utils = new InterCaseTestUtils(this);
     }

--- a/Core/test/qa-functional/src/org/sleuthkit/autopsy/commonpropertiessearch/IngestedWithHashAndFileTypeInterCaseTest.java
+++ b/Core/test/qa-functional/src/org/sleuthkit/autopsy/commonpropertiessearch/IngestedWithHashAndFileTypeInterCaseTest.java
@@ -47,18 +47,18 @@ import org.sleuthkit.datamodel.TskCoreException;
  * all data sources: One node for Hash C (3_1_C.jpg, 3_2_C.jpg)
  *
  */
-public class IngestedWithHashAndFileTypeInterCaseTests extends NbTestCase {
+public class IngestedWithHashAndFileTypeInterCaseTest extends NbTestCase {
 
     private final InterCaseTestUtils utils;
 
     public static Test suite() {
-        NbModuleSuite.Configuration conf = NbModuleSuite.createConfiguration(IngestedWithHashAndFileTypeInterCaseTests.class).
+        NbModuleSuite.Configuration conf = NbModuleSuite.createConfiguration(IngestedWithHashAndFileTypeInterCaseTest.class).
                 clusters(".*").
                 enableModules(".*");
         return conf.suite();
     }
 
-    public IngestedWithHashAndFileTypeInterCaseTests(String name) {
+    public IngestedWithHashAndFileTypeInterCaseTest(String name) {
         super(name);
         this.utils = new InterCaseTestUtils(this);
     }

--- a/Core/test/qa-functional/src/org/sleuthkit/autopsy/commonpropertiessearch/IngestedWithHashAndFileTypeIntraCaseTest.java
+++ b/Core/test/qa-functional/src/org/sleuthkit/autopsy/commonpropertiessearch/IngestedWithHashAndFileTypeIntraCaseTest.java
@@ -48,10 +48,10 @@ import org.sleuthkit.datamodel.TskCoreException;
 /**
  * Add set 1, set 2, set 3, and set 4 to case and ingest with hash algorithm.
  */
-public class IngestedWithHashAndFileTypeIntraCaseTests extends NbTestCase {
+public class IngestedWithHashAndFileTypeIntraCaseTest extends NbTestCase {
 
     public static Test suite() {
-        NbModuleSuite.Configuration conf = NbModuleSuite.createConfiguration(IngestedWithHashAndFileTypeIntraCaseTests.class).
+        NbModuleSuite.Configuration conf = NbModuleSuite.createConfiguration(IngestedWithHashAndFileTypeIntraCaseTest.class).
                 clusters(".*").
                 enableModules(".*");
         return conf.suite();
@@ -59,7 +59,7 @@ public class IngestedWithHashAndFileTypeIntraCaseTests extends NbTestCase {
 
     private final IntraCaseTestUtils utils;
 
-    public IngestedWithHashAndFileTypeIntraCaseTests(String name) {
+    public IngestedWithHashAndFileTypeIntraCaseTest(String name) {
         super(name);
 
         this.utils = new IntraCaseTestUtils(this, "IngestedWithHashAndFileTypeTests");
@@ -76,7 +76,7 @@ public class IngestedWithHashAndFileTypeIntraCaseTests extends NbTestCase {
         templates.add(hashLookupTemplate);
         templates.add(mimeTypeLookupTemplate);
 
-        IngestJobSettings ingestJobSettings = new IngestJobSettings(IngestedWithHashAndFileTypeIntraCaseTests.class.getCanonicalName(), IngestType.FILES_ONLY, templates);
+        IngestJobSettings ingestJobSettings = new IngestJobSettings(IngestedWithHashAndFileTypeIntraCaseTest.class.getCanonicalName(), IngestType.FILES_ONLY, templates);
 
         try {
             IngestUtils.runIngestJob(Case.getCurrentCaseThrows().getDataSources(), ingestJobSettings);

--- a/Core/test/qa-functional/src/org/sleuthkit/autopsy/commonpropertiessearch/IngestedWithNoFileTypesIntraCaseTest.java
+++ b/Core/test/qa-functional/src/org/sleuthkit/autopsy/commonpropertiessearch/IngestedWithNoFileTypesIntraCaseTest.java
@@ -51,10 +51,10 @@ import org.sleuthkit.datamodel.TskCoreException;
  * Add images set 1, set 2, set 3, and set 4 to case. Do not run mime type
  * module.
  */
-public class IngestedWithNoFileTypesIntraCaseTests extends NbTestCase {
+public class IngestedWithNoFileTypesIntraCaseTest extends NbTestCase {
 
     public static Test suite() {
-        NbModuleSuite.Configuration conf = NbModuleSuite.createConfiguration(IngestedWithNoFileTypesIntraCaseTests.class).
+        NbModuleSuite.Configuration conf = NbModuleSuite.createConfiguration(IngestedWithNoFileTypesIntraCaseTest.class).
                 clusters(".*").
                 enableModules(".*");
         return conf.suite();
@@ -62,7 +62,7 @@ public class IngestedWithNoFileTypesIntraCaseTests extends NbTestCase {
 
     private final IntraCaseTestUtils utils;
     
-    public IngestedWithNoFileTypesIntraCaseTests(String name) {
+    public IngestedWithNoFileTypesIntraCaseTest(String name) {
         super(name);
         
         this.utils = new IntraCaseTestUtils(this, "IngestedWithNoFileTypes");
@@ -77,7 +77,7 @@ public class IngestedWithNoFileTypesIntraCaseTests extends NbTestCase {
         ArrayList<IngestModuleTemplate> templates = new ArrayList<>();
         templates.add(hashLookupTemplate);
 
-        IngestJobSettings ingestJobSettings = new IngestJobSettings(IngestedWithNoFileTypesIntraCaseTests.class.getCanonicalName(), IngestJobSettings.IngestType.FILES_ONLY, templates);
+        IngestJobSettings ingestJobSettings = new IngestJobSettings(IngestedWithNoFileTypesIntraCaseTest.class.getCanonicalName(), IngestJobSettings.IngestType.FILES_ONLY, templates);
 
         try {
             IngestUtils.runIngestJob(Case.getCurrentCaseThrows().getDataSources(), ingestJobSettings);

--- a/Core/test/qa-functional/src/org/sleuthkit/autopsy/commonpropertiessearch/MatchesInAtLeastTwoSourcesIntraCaseTest.java
+++ b/Core/test/qa-functional/src/org/sleuthkit/autopsy/commonpropertiessearch/MatchesInAtLeastTwoSourcesIntraCaseTest.java
@@ -53,10 +53,10 @@ import org.sleuthkit.datamodel.TskCoreException;
  *
  * None of the test files should be found in the results of this test.
  */
-public class MatchesInAtLeastTwoSourcesIntraCaseTests extends NbTestCase {
+public class MatchesInAtLeastTwoSourcesIntraCaseTest extends NbTestCase {
 
     public static Test suite() {
-        NbModuleSuite.Configuration conf = NbModuleSuite.createConfiguration(MatchesInAtLeastTwoSourcesIntraCaseTests.class).
+        NbModuleSuite.Configuration conf = NbModuleSuite.createConfiguration(MatchesInAtLeastTwoSourcesIntraCaseTest.class).
                 clusters(".*").
                 enableModules(".*");
         return conf.suite();
@@ -64,7 +64,7 @@ public class MatchesInAtLeastTwoSourcesIntraCaseTests extends NbTestCase {
 
     private final IntraCaseTestUtils utils;
 
-    public MatchesInAtLeastTwoSourcesIntraCaseTests(String name) {
+    public MatchesInAtLeastTwoSourcesIntraCaseTest(String name) {
         super(name);
 
         this.utils = new IntraCaseTestUtils(this, "MatchesInAtLeastTwoSources");
@@ -86,7 +86,7 @@ public class MatchesInAtLeastTwoSourcesIntraCaseTests extends NbTestCase {
         templates.add(hashLookupTemplate);
         templates.add(mimeTypeLookupTemplate);
 
-        IngestJobSettings ingestJobSettings = new IngestJobSettings(IngestedWithHashAndFileTypeIntraCaseTests.class.getCanonicalName(), IngestJobSettings.IngestType.FILES_ONLY, templates);
+        IngestJobSettings ingestJobSettings = new IngestJobSettings(IngestedWithHashAndFileTypeIntraCaseTest.class.getCanonicalName(), IngestJobSettings.IngestType.FILES_ONLY, templates);
 
         try {
             IngestUtils.runIngestJob(Case.getCurrentCaseThrows().getDataSources(), ingestJobSettings);

--- a/Core/test/qa-functional/src/org/sleuthkit/autopsy/commonpropertiessearch/UningestedCasesIntraCaseTest.java
+++ b/Core/test/qa-functional/src/org/sleuthkit/autopsy/commonpropertiessearch/UningestedCasesIntraCaseTest.java
@@ -45,10 +45,10 @@ import org.sleuthkit.datamodel.TskCoreException;
  * Add images set 1, set 2, set 3, and set 4 to case. Do not ingest.
  *
  */
-public class UningestedCasesIntraCaseTests extends NbTestCase {
+public class UningestedCasesIntraCaseTest extends NbTestCase {
 
     public static Test suite() {
-        NbModuleSuite.Configuration conf = NbModuleSuite.createConfiguration(UningestedCasesIntraCaseTests.class).
+        NbModuleSuite.Configuration conf = NbModuleSuite.createConfiguration(UningestedCasesIntraCaseTest.class).
                 clusters(".*").
                 enableModules(".*");
         return conf.suite();
@@ -56,7 +56,7 @@ public class UningestedCasesIntraCaseTests extends NbTestCase {
 
     private final IntraCaseTestUtils utils;
     
-    public UningestedCasesIntraCaseTests(String name) {
+    public UningestedCasesIntraCaseTest(String name) {
         super(name);
         
         this.utils = new IntraCaseTestUtils(this, "UningestedCasesTests");


### PR DESCRIPTION
Take for example the ingest package tests. Netbeans will literally run something like: "ant -f Core -Dtest.includes=org/sleuthkit/autopsy/ingest/**/*Test.java test-single" to gather and execute the ingest tests. This is fine because all ingest test files end with 'Test.java'. The test files in commonpropertiessearch package, however, all end with 'Tests.java' so Netbeans is missing them. This means you cannot test them from Netbeans and they are not being run in the nightly builds. 

This PR changes the name so that they are rediscovered.