### PR TITLE
Fix TskDbDiff CSV Splitting

### DIFF
--- a/test/script/tskdbdiff.py
+++ b/test/script/tskdbdiff.py
@@ -437,7 +437,7 @@ def normalize_db_entry(line, files_table, vs_parts_table, vs_info_table, fs_info
     ig_groups_seen_index = line.find('INSERT INTO "image_gallery_groups_seen"') > -1 or line.find('INSERT INTO image_gallery_groups_seen ') > -1
     
     parens = line[line.find('(') + 1 : line.rfind(')')]
-    fields_list = list(csv.reader([parens], quotechar="'"))[0]
+    fields_list = list(csv.reader([parens.replace(" ", "")], quotechar="'"))[0]
 
     # remove object ID
     if files_index:

--- a/test/script/tskdbdiff.py
+++ b/test/script/tskdbdiff.py
@@ -11,6 +11,7 @@ import sys
 import psycopg2
 import psycopg2.extras
 import socket
+import csv
 
 class TskDbDiff(object):
     """Compares two TSK/Autospy SQLite databases.
@@ -436,8 +437,8 @@ def normalize_db_entry(line, files_table, vs_parts_table, vs_info_table, fs_info
     ig_groups_seen_index = line.find('INSERT INTO "image_gallery_groups_seen"') > -1 or line.find('INSERT INTO image_gallery_groups_seen ') > -1
     
     parens = line[line.find('(') + 1 : line.rfind(')')]
-    fields_list = parens.replace(" ", "").split(',')
-    
+    fields_list = list(csv.reader([parens], quotechar="'"))[0]
+
     # remove object ID
     if files_index:
         newLine = ('INSERT INTO "tsk_files" VALUES(' + ', '.join(fields_list[1:]) + ');') 


### PR DESCRIPTION
This PR fixes the CSV split for "INSERT INTO .... VALUES (a, b, c, d,)" statements. Our current approach is fooled if a or b is a string containing a comma.

This will fix regression failures on the tsk_event_descriptions table. However, this may introduce corrected diffs as this split routine was used by all INSERT statements.