### PR TITLE
5536-uneeded-log-messages-about-fileviewer

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/contentviewers/FileViewer.java
+++ b/Core/src/org/sleuthkit/autopsy/contentviewers/FileViewer.java
@@ -117,7 +117,7 @@ public class FileViewer extends javax.swing.JPanel implements DataContentViewer 
         }
 
         AbstractFile file = selectedNode.getLookup().lookup(AbstractFile.class);
-        if (file == null) {
+        if ((file == null) || (file.isDir())) {
             return;
         }
 
@@ -189,7 +189,7 @@ public class FileViewer extends javax.swing.JPanel implements DataContentViewer 
         }
 
         AbstractFile aFile = node.getLookup().lookup(AbstractFile.class);
-        if (aFile == null) {
+        if ((aFile == null) || (aFile.isDir())) {
             return false;
         }
 


### PR DESCRIPTION
Add check if abstractfile is a directory and ignore if it is.