### PR TITLE
5587: Error from ShareIt module

### DIFF
--- a/InternalPythonModules/android/general.py
+++ b/InternalPythonModules/android/general.py
@@ -34,6 +34,6 @@ def appendAttachmentList(msgBody, attachmentsList):
     body = msgBody
     if attachmentsList:
         body = body + "\n\n------------Attachments------------\n"
-        body = body + "\n".join(attachmentsList)
+        body = body + "\n".join(list(filter(None, attachmentsList)))
 
     return body


### PR DESCRIPTION
 - filter out Null & blank strings while appending attachments list to msg body.