### PR TITLE
Set the internal name of the InterestingItemTypeNode to be something …

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/datamodel/InterestingHits.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/InterestingHits.java
@@ -399,7 +399,12 @@ public class InterestingHits implements AutopsyVisitableItem {
             super(Children.create(new HitFactory(setName, typeName), true), Lookups.singleton(setName));
             this.typeName = typeName;
             this.setName = setName;
-            super.setName(typeName);
+            /**
+             * We use the combination of setName and typeName as the name of
+             * the node to ensure that nodes have a unique name. This comes into
+             * play when associating paging state with the node.
+             */
+            super.setName(setName + "_" + typeName);
             updateDisplayName();
             this.setIconBaseWithExtension("org/sleuthkit/autopsy/images/interesting_item.png"); //NON-NLS
             interestingResults.addObserver(this);
@@ -456,7 +461,12 @@ public class InterestingHits implements AutopsyVisitableItem {
         private final Map<Long, BlackboardArtifact> artifactHits = new HashMap<>();
 
         private HitFactory(String setName, String typeName) {
-            super(typeName);
+            /**
+             * The node name passed to the parent constructor must be the
+             * same as the name set in the InterestingItemTypeNode constructor,
+             * i.e. setName underscore typeName
+             */
+            super(setName + "_" + typeName);
             this.setName = setName;
             this.typeName = typeName;
             interestingResults.addObserver(this);


### PR DESCRIPTION
…that is unique so that paging works correctly when a user switches back and forth between multiple different interesting file/result sets.