### PR TITLE
Don't make building dependent on downloading test data files. Our Tra…

### DIFF
--- a/Core/build.xml
+++ b/Core/build.xml
@@ -137,7 +137,7 @@
 
     </target>
 
-    <target name="get-deps" depends="init-ivy,getTSKJars,get-thirdparty-dependencies,get-InternalPythonModules, download-binlist,getTestDataFiles">
+    <target name="get-deps" depends="init-ivy,getTSKJars,get-thirdparty-dependencies,get-InternalPythonModules, download-binlist">
         <mkdir dir="${ext.dir}"/>
         <copy file="${thirdparty.dir}/LICENSE-2.0.txt" todir="${ext.dir}" />        
         <!-- fetch all the dependencies from Ivy and stick them in the right places -->


### PR DESCRIPTION
…vis build occasionally fails when attempting to download these files. Ideally these files should be downloaded only if tests are to be run that require them.