### PR TITLE
Rework INSERT OR REPLACE in DrawableDB for cascading data source deletes

### DIFF
--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/BulkDrawableFilesTask.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/BulkDrawableFilesTask.java
@@ -36,8 +36,8 @@ import org.sleuthkit.datamodel.TskData;
  * records for multiple drawable files.
  */
 @NbBundle.Messages({
-    "BulkDrawableFilesTask.committingDb.status=committing image/video database", 
-    "BulkDrawableFilesTask.stopCopy.status=Stopping copy to drawable db task.", 
+    "BulkDrawableFilesTask.committingDb.status=committing image/video database",
+    "BulkDrawableFilesTask.stopCopy.status=Stopping copy to drawable db task.",
     "BulkDrawableFilesTask.errPopulating.errMsg=There was an error populating Image Gallery database."
 })
 abstract class BulkDrawableFilesTask extends DrawableDbTask {
@@ -58,7 +58,7 @@ abstract class BulkDrawableFilesTask extends DrawableDbTask {
         this.taskDB = controller.getDrawablesDatabase();
         this.tskCase = controller.getCaseDatabase();
         this.dataSourceObjId = dataSourceObjId;
-        drawableQuery = " (data_source_obj_id = " + dataSourceObjId + ") " 
+        drawableQuery = " (data_source_obj_id = " + dataSourceObjId + ") "
                 + " AND ( meta_type = " + TskData.TSK_FS_META_TYPE_ENUM.TSK_FS_META_TYPE_REG.getValue() + ")" + " AND ( " + MIMETYPE_CLAUSE //NON-NLS
                 + " OR mime_type LIKE 'video/%' OR mime_type LIKE 'image/%' )" //NON-NLS
                 + " ORDER BY parent_path ";
@@ -171,7 +171,11 @@ abstract class BulkDrawableFilesTask extends DrawableDbTask {
             // Mark to REBUILT_STALE if some files didnt' have MIME (ingest was still ongoing) or
             // if there was cancellation or errors
             DrawableDB.DrawableDbBuildStatusEnum datasourceDrawableDBStatus = ((hasFilesWithNoMime == true) || (endedEarly == true)) ? DrawableDB.DrawableDbBuildStatusEnum.REBUILT_STALE : DrawableDB.DrawableDbBuildStatusEnum.COMPLETE;
-            taskDB.insertOrUpdateDataSource(dataSourceObjId, datasourceDrawableDBStatus);
+            try {
+                taskDB.insertOrUpdateDataSource(dataSourceObjId, datasourceDrawableDBStatus);
+            } catch (SQLException ex) {
+                logger.log(Level.SEVERE, String.format("Error updating datasources table (data source object ID = %d, status = %s)", dataSourceObjId, datasourceDrawableDBStatus.toString(), ex)); //NON-NLS
+            }
             updateMessage("");
             updateProgress(-1.0);
         }

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/ImageGalleryController.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/ImageGalleryController.java
@@ -801,7 +801,11 @@ public final class ImageGalleryController {
                         if (((AutopsyEvent) event).getSourceType() == AutopsyEvent.SourceType.LOCAL) {
                             Content newDataSource = (Content) event.getNewValue();
                             if (isListeningEnabled()) {
-                                drawableDB.insertOrUpdateDataSource(newDataSource.getId(), DrawableDB.DrawableDbBuildStatusEnum.UNKNOWN);
+                                try {
+                                    drawableDB.insertOrUpdateDataSource(newDataSource.getId(), DrawableDB.DrawableDbBuildStatusEnum.UNKNOWN);
+                                } catch (SQLException ex) {
+                                    logger.log(Level.SEVERE, String.format("Error updating datasources table (data source object ID = %d, status = %s)", newDataSource.getId(), DrawableDB.DrawableDbBuildStatusEnum.UNKNOWN.toString(), ex)); //NON-NLS
+                                }
                             }
                         }
                         break;
@@ -883,7 +887,7 @@ public final class ImageGalleryController {
                     default:
                         break;
                 }
-            } catch (TskCoreException ex) {
+            } catch (TskCoreException | SQLException ex) {
                 logger.log(Level.SEVERE, String.format("Failed to handle %s event for %s (objId=%d)", dataSourceEvent.getPropertyName(), dataSource.getName(), dataSourceObjId), ex);
             }
         }
@@ -898,7 +902,7 @@ public final class ImageGalleryController {
      * @throws TskCoreException If there is an error adding the data source to
      *                          the database.
      */
-    private void handleDataSourceAnalysisStarted(DataSourceAnalysisEvent event) throws TskCoreException {
+    private void handleDataSourceAnalysisStarted(DataSourceAnalysisEvent event) throws TskCoreException, SQLException {
         if (event.getSourceType() == AutopsyEvent.SourceType.LOCAL && isListeningEnabled()) {
             Content dataSource = event.getDataSource();
             long dataSourceObjId = dataSource.getId();
@@ -919,7 +923,7 @@ public final class ImageGalleryController {
      * @throws TskCoreException If there is an error updating the state ot the
      *                          data source in the database.
      */
-    private void handleDataSourceAnalysisCompleted(DataSourceAnalysisEvent event) throws TskCoreException {
+    private void handleDataSourceAnalysisCompleted(DataSourceAnalysisEvent event) throws TskCoreException, SQLException {
         if (event.getSourceType() == AutopsyEvent.SourceType.LOCAL) {
             Content dataSource = event.getDataSource();
             long dataSourceObjId = dataSource.getId();

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/DrawableDB.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/DrawableDB.java
@@ -1716,20 +1716,20 @@ public final class DrawableDB {
     public void insertOrUpdateDataSource(long dataSourceObjectID, DrawableDbBuildStatusEnum status) throws SQLException {
         dbWriteLock();
         try {
+            // SELECT COUNT(*) FROM datasources WHERE ds_obj_id = ?
             selectCountDataSourceIDs.setLong(1, dataSourceObjectID);
             try (ResultSet resultSet = selectCountDataSourceIDs.executeQuery()) {
-                if (resultSet.first()) {
-                    if (resultSet.getInt(1) == 0) {
-                        insertDataSourceStmt.setLong(1, dataSourceObjectID);
-                        insertDataSourceStmt.setString(2, status.name());
-                        insertDataSourceStmt.execute();
-                    } else {
-                        updateDataSourceStmt.setString(1, status.name());
-                        updateDataSourceStmt.setLong(2, dataSourceObjectID);
-                        updateDataSourceStmt.executeUpdate();
-                    }
+                resultSet.first();
+                if (resultSet.getInt(1) == 0) {
+                    // INSERT INTO datasources (ds_obj_id, drawable_db_build_status) VALUES (?,?)
+                    insertDataSourceStmt.setLong(1, dataSourceObjectID);
+                    insertDataSourceStmt.setString(2, status.name());
+                    insertDataSourceStmt.execute();
                 } else {
-                    throw new SQLException("SELECT COUNT(*) query of datasources table failed to return any rows");
+                    // UPDATE datasources SET drawable_db_build_status = ? WHERE ds_obj_id = ?
+                    updateDataSourceStmt.setString(1, status.name());
+                    updateDataSourceStmt.setLong(2, dataSourceObjectID);
+                    updateDataSourceStmt.executeUpdate();
                 }
             }
         } finally {

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/DrawableDB.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/DrawableDB.java
@@ -196,8 +196,8 @@ public final class DrawableDB {
      * to the data sources in the case.
      *
      * IMPORTANT: ADD NEW STATUSES TO THE END OF THE LIST TODO: I'm (RC) not
-     * sure why this is required, it looks like the enum elemnt names are
-     * strored in the image gallery database. Are the raw cardinal values used
+     * sure why this is required, it looks like the enum elemnt names are stored
+     * in the image gallery database. Are the raw cardinal values used
      * somewhere?
      */
     public enum DrawableDbBuildStatusEnum {
@@ -1706,18 +1706,18 @@ public final class DrawableDB {
     /**
      * Inserts the given data source object ID and its status into the
      * datasources table. If a record for the data source already exists, an
-     * update of the status is doen instead.
+     * update of the status is done instead.
      *
      * @param dataSourceObjectID A data source object ID from the case database.
      * @param status             The status of the data source with respect to
      *                           populating the image gallery database.
      */
-    public void insertOrUpdateDataSource(long dataSourceObjectID, DrawableDbBuildStatusEnum status) {
+    public void insertOrUpdateDataSource(long dataSourceObjectID, DrawableDbBuildStatusEnum status) throws SQLException {
         dbWriteLock();
         try {
             selectCountDataSourceIDs.setLong(1, dataSourceObjectID);
             try (ResultSet resultSet = selectCountDataSourceIDs.executeQuery()) {
-                if (resultSet.next()) {
+                if (resultSet.first()) {
                     if (resultSet.getInt(1) == 0) {
                         insertDataSourceStmt.setLong(1, dataSourceObjectID);
                         insertDataSourceStmt.setString(2, status.name());
@@ -1728,11 +1728,9 @@ public final class DrawableDB {
                         updateDataSourceStmt.executeUpdate();
                     }
                 } else {
-                    logger.log(Level.SEVERE, String.format("Error querying datasources table (data source object ID = %d, status = %s)", dataSourceObjectID, status.toString())); //NON-NLS
+                    throw new SQLException("SELECT COUNT(*) query of datasources table failed to return any rows");
                 }
             }
-        } catch (SQLException ex) {
-            logger.log(Level.SEVERE, String.format("Error querying/updating datasources table (data source object ID = %d, status = %s)", dataSourceObjectID, status.toString()), ex); //NON-NLS
         } finally {
             dbWriteUnlock();
         }

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/DrawableDB.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/DrawableDB.java
@@ -198,7 +198,7 @@ public final class DrawableDB {
      * IMPORTANT: ADD NEW STATUSES TO THE END OF THE LIST
      *
      * TODO: I'm (RC) not sure why this is required, it looks like the enum
-     * elemnt names are stored in the image gallery database. Are the raw
+     * element names are stored in the image gallery database. Are the raw
      * cardinal values used somewhere?
      */
     public enum DrawableDbBuildStatusEnum {

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/DrawableDB.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/DrawableDB.java
@@ -195,10 +195,11 @@ public final class DrawableDB {
      * Enum for tracking the status of the image gallery database with respect
      * to the data sources in the case.
      *
-     * IMPORTANT: ADD NEW STATUSES TO THE END OF THE LIST TODO: I'm (RC) not
-     * sure why this is required, it looks like the enum elemnt names are stored
-     * in the image gallery database. Are the raw cardinal values used
-     * somewhere?
+     * IMPORTANT: ADD NEW STATUSES TO THE END OF THE LIST
+     *
+     * TODO: I'm (RC) not sure why this is required, it looks like the enum
+     * elemnt names are stored in the image gallery database. Are the raw
+     * cardinal values used somewhere?
      */
     public enum DrawableDbBuildStatusEnum {
         /**


### PR DESCRIPTION
For DrawableDB.insertOrUpdateDataSource, a single INSERT OR REPLACE SQL command for the image gallery datasources table is no longer viable as a dual purpose insert/update operation now that deleting rows in that table cascades to other tables. This PR implements branching to use either INSERT or UPDATE SQL, depending on whether a given data source has already been added to the image gallery database.

Note that I also made the DrawableDB.insertOrUpdateDataSource method propagate exceptions to its callers, consistent with our error handling policy.