### PR TITLE
5801-cvt-should-change-to-summary-panel-when-account-selection-changes

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/communications/relationships/RelationshipBrowser.java
+++ b/Core/src/org/sleuthkit/autopsy/communications/relationships/RelationshipBrowser.java
@@ -61,6 +61,7 @@ public final class RelationshipBrowser extends JPanel implements Lookup.Provider
      */
     public void setSelectionInfo(SelectionInfo info) {
         currentSelection = info;
+        tabPane.setSelectedIndex(0);
         ((RelationshipsViewer) tabPane.getSelectedComponent()).setSelectionInfo(info);
     }
 


### PR DESCRIPTION
Set selected index for panel back to summary for each selection instead of staying on the currently selected tab