### PR TITLE
5804 No timeline data if some ingest modules not run

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/timeline/EventsModel.java
+++ b/Core/src/org/sleuthkit/autopsy/timeline/EventsModel.java
@@ -185,7 +185,7 @@ public final class EventsModel {
          * RJCTODO: Why isn't the event filter state of the initialModelParams
          * used here?
          */
-        filterStateProperty.set(getDefaultEventFilter());
+        filterStateProperty.set(getDefaultEventFilterState());
 
         /*
          * Add a listener to the model parameters property that updates the
@@ -405,11 +405,24 @@ public final class EventsModel {
      *
      * @return An instance of the default filter state model parameter.
      */
-    public synchronized RootFilterState getDefaultEventFilter() {
+    public synchronized RootFilterState getDefaultEventFilterState() {
+        // RJCTODO: Move all of this into FilterUtils, or factor FilterUtils 
+        // into this class. The former is probably better, simply passing the 
+        // util a list of data source names.
+        /*
+         * Construct data source filters for all of the data sources in the data
+         * sources cache.
+         */
         DataSourcesFilter dataSourcesFilter = new DataSourcesFilter();
         datasourceIDsToNamesMap.entrySet().forEach(dataSourceEntry
                 -> dataSourcesFilter.addSubFilter(newDataSourceFilter(dataSourceEntry)));
-        return new RootFilterState(new RootFilter(new HideKnownFilter(),
+
+        /*
+         * Make the rest of the event filters and decorate all of the filters
+         * with filter state objects for the GUI.
+         */
+        RootFilterState rootFilterState = new RootFilterState(new RootFilter(
+                new HideKnownFilter(),
                 new TagsFilter(),
                 new HashHitsFilter(),
                 new TextFilter(),
@@ -417,6 +430,8 @@ public final class EventsModel {
                 dataSourcesFilter,
                 FilterUtils.createDefaultFileTypesFilter(),
                 Collections.emptySet()));
+
+        return rootFilterState;
     }
 
     /**

--- a/Core/src/org/sleuthkit/autopsy/timeline/TimeLineController.java
+++ b/Core/src/org/sleuthkit/autopsy/timeline/TimeLineController.java
@@ -323,7 +323,7 @@ public class TimeLineController {
     }
 
     public void applyDefaultFilters() {
-        pushFilters(filteredEvents.getDefaultEventFilter());
+        pushFilters(filteredEvents.getDefaultEventFilterState());
     }
 
     public void zoomOutToActivity() throws TskCoreException {

--- a/Core/src/org/sleuthkit/autopsy/timeline/actions/ResetFilters.java
+++ b/Core/src/org/sleuthkit/autopsy/timeline/actions/ResetFilters.java
@@ -49,7 +49,7 @@ public class ResetFilters extends Action {
 
             @Override
             protected boolean computeValue() {
-                return eventsModel.modelParamsProperty().getValue().getEventFilterState().equals(eventsModel.getDefaultEventFilter());
+                return eventsModel.modelParamsProperty().getValue().getEventFilterState().equals(eventsModel.getDefaultEventFilterState());
             }
         });
         setEventHandler((ActionEvent t) -> {

--- a/Core/src/org/sleuthkit/autopsy/timeline/ui/filtering/Bundle.properties-MERGED
+++ b/Core/src/org/sleuthkit/autopsy/timeline/ui/filtering/Bundle.properties-MERGED
@@ -1,7 +1,7 @@
 FilsetSetPanel.hiddenDescriptionsPane.displayName=Hidden Descriptions
 FilterSetPanel.applyButton.longText=(Re)Apply filters
 FilterSetPanel.applyButton.text=Apply
-FilterSetPanel.defaultButton.text=Default
+FilterSetPanel.defaultButton.text=Reset
 FilterSetPanel.hiddenDescriptionsListView.remove=Remove from list
 FilterSetPanel.hiddenDescriptionsListView.unhideAndRemove=Unhide and remove from list
 Timeline.ui.filtering.menuItem.all=all

--- a/Core/src/org/sleuthkit/autopsy/timeline/ui/filtering/FilterSetPanel.java
+++ b/Core/src/org/sleuthkit/autopsy/timeline/ui/filtering/FilterSetPanel.java
@@ -90,7 +90,7 @@ final public class FilterSetPanel extends BorderPane {
     private double dividerPosition;
 
     @NbBundle.Messages({
-        "FilterSetPanel.defaultButton.text=Default",
+        "FilterSetPanel.defaultButton.text=Reset",
         "FilsetSetPanel.hiddenDescriptionsPane.displayName=Hidden Descriptions"})
     @FXML
     void initialize() {

--- a/Core/src/org/sleuthkit/autopsy/timeline/ui/filtering/datamodel/CompoundFilterState.java
+++ b/Core/src/org/sleuthkit/autopsy/timeline/ui/filtering/datamodel/CompoundFilterState.java
@@ -150,7 +150,7 @@ public class CompoundFilterState<SubFilterType extends TimelineFilter, FilterTyp
         if (subFilterStates.contains(newSubFilterState) == false) {
             subFilterStates.add(newSubFilterState);
             newSubFilterState.selectedProperty().addListener(selectedProperty -> {
-                //set this compound filter state selected af any of the subfilters are selected.
+                //set this compound filter state selected if any of the subfilters are selected.
                 setSelected(subFilterStates.stream().anyMatch(FilterState::isSelected));
             });
             newSubFilterState.setDisabled(isActive() == false);

--- a/Core/src/org/sleuthkit/autopsy/timeline/ui/filtering/datamodel/SqlFilterState.java
+++ b/Core/src/org/sleuthkit/autopsy/timeline/ui/filtering/datamodel/SqlFilterState.java
@@ -24,27 +24,33 @@ import org.sleuthkit.datamodel.TimelineFilter;
  * Default FilterState implementation for individual TimelineFilters.
  *
  * @param <FilterType>
+ *
+ * RJCTODO: We need a better name for this class. Or at least an explanation of
+ * the SQL in the name. The SQL part is not actually enforced or even implied.
+ * IT can only be known by knowledge of the filter hierarchy underlying the
+ * filter states hierarchy.
  */
 public class SqlFilterState<FilterType extends TimelineFilter> extends AbstractFilterState<FilterType> {
+
     /**
      * Selected = false, Disabled = false
      *
      * @param filter
      */
     public SqlFilterState(FilterType filter) {
-        // Setting the intial state to all filters to "selected" except
-        // the "Hide Known Filters", "Tags", "Hashsets" and "Text".
-        // There are better ways to do this, but this works in a pinch
-        this(filter, !(filter instanceof TimelineFilter.HideKnownFilter || filter instanceof TimelineFilter.TagsFilter || filter instanceof TimelineFilter.HashHitsFilter || filter instanceof TimelineFilter.TextFilter));
-        
-         selectedProperty().addListener(selectedProperty -> {
-           if (filter instanceof TimelineFilter.TagsFilter) {
-               ((TimelineFilter.TagsFilter)filter).setEventSourcesAreTagged(isSelected());
-           } else  if (filter instanceof TimelineFilter.HashHitsFilter) {
-               ((TimelineFilter.HashHitsFilter)filter).setEventSourcesHaveHashSetHits(isSelected());
-           }
+        this(filter, false);
+        /*
+         * RJCTODO: This casting is not very nice. We should insert filter state
+         * classes for these two types of filters as subclasses of
+         * SqlFilterState.
+         */
+        selectedProperty().addListener(selectedProperty -> {
+            if (filter instanceof TimelineFilter.TagsFilter) {
+                ((TimelineFilter.TagsFilter) filter).setEventSourcesAreTagged(isSelected());
+            } else if (filter instanceof TimelineFilter.HashHitsFilter) {
+                ((TimelineFilter.HashHitsFilter) filter).setEventSourcesHaveHashSetHits(isSelected());
+            }
         });
-        
     }
 
     /**
@@ -74,9 +80,9 @@ public class SqlFilterState<FilterType extends TimelineFilter> extends AbstractF
     @Override
     public String toString() {
         return "TimelineFilterState{"
-               + " filter=" + getFilter().toString()
-               + ", selected=" + isSelected()
-               + ", disabled=" + isDisabled()
-               + ", activeProp=" + isActive() + '}'; //NON-NLS
+                + " filter=" + getFilter().toString()
+                + ", selected=" + isSelected()
+                + ", disabled=" + isDisabled()
+                + ", activeProp=" + isActive() + '}'; //NON-NLS
     }
 }

--- a/Core/src/org/sleuthkit/autopsy/timeline/utils/FilterUtils.java
+++ b/Core/src/org/sleuthkit/autopsy/timeline/utils/FilterUtils.java
@@ -54,12 +54,10 @@ public final class FilterUtils {
         "FilterUtils.otherFilter.displayName=Other"})
     public static FileTypesFilter createDefaultFileTypesFilter() {
         FileTypesFilter fileTypesFilter = new FileTypesFilter();
-
         fileTypesFilter.addSubFilter(new FileTypeFilter(MEDIA.getDisplayName(), MEDIA.getMediaTypes()));
         fileTypesFilter.addSubFilter(new FileTypeFilter(DOCUMENTS.getDisplayName(), DOCUMENTS.getMediaTypes()));
         fileTypesFilter.addSubFilter(new FileTypeFilter(EXECUTABLE.getDisplayName(), EXECUTABLE.getMediaTypes()));
         fileTypesFilter.addSubFilter(new InverseFileTypeFilter(Bundle.FilterUtils_otherFilter_displayName(), NON_OTHER_MIME_TYPES));
-
         return fileTypesFilter;
     }
 }


### PR DESCRIPTION
* Made all timeline filters disabled by default. This way the lack of file types if ingest has not been run does not produce an empty display by default.
* Changed filter display names as desired by Brian Carrier.
* Changed reset button label from "Default" to "Reset" as desired by Brian Carrier. 

See also: https://github.com/sleuthkit/sleuthkit/pull/1704.