### PR TITLE
5902-image_gallery_groups-table-still-has-entries-for-deleted-datasources

### DIFF
--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/DrawableDB.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/DrawableDB.java
@@ -2156,7 +2156,9 @@ public final class DrawableDB {
             trans = beginTransaction();
             deleteDataSourceStmt.setLong(1, dataSourceID);
             deleteDataSourceStmt.executeUpdate();
-            caseDb.getCaseDbAccessManager().delete(tableName, whereClause);
+            if (caseDb.getCaseDbAccessManager().tableExists(tableName)) {
+                caseDb.getCaseDbAccessManager().delete(tableName, whereClause);
+            }
             commitTransaction(trans, true);
         } catch (SQLException | TskCoreException ex) {
             if (null != trans) {

--- a/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/DrawableDB.java
+++ b/ImageGallery/src/org/sleuthkit/autopsy/imagegallery/datamodel/DrawableDB.java
@@ -2150,10 +2150,13 @@ public final class DrawableDB {
     public void deleteDataSource(long dataSourceID) throws SQLException, TskCoreException {
         dbWriteLock();
         DrawableTransaction trans = null;
+        String whereClause = "WHERE data_source_obj_id = " + dataSourceID;
+        String tableName = "image_gallery_groups";
         try {
             trans = beginTransaction();
             deleteDataSourceStmt.setLong(1, dataSourceID);
             deleteDataSourceStmt.executeUpdate();
+            caseDb.getCaseDbAccessManager().delete(tableName, whereClause);
             commitTransaction(trans, true);
         } catch (SQLException | TskCoreException ex) {
             if (null != trans) {


### PR DESCRIPTION
Delete data source from image_gallery_groups table when data source is deleted from image gallery 