### PR TITLE
5918-Hover-text-for-Source-File-column-for-artifacts-is-incorrect

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/datamodel/BlackboardArtifactNode.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/BlackboardArtifactNode.java
@@ -312,7 +312,11 @@ public class BlackboardArtifactNode extends AbstractContentNode<BlackboardArtifa
         }
 
         if (displayName.isEmpty() && artifact != null) {
-            displayName = artifact.getName();
+            try {
+                displayName = Case.getCurrentCaseThrows().getSleuthkitCase().getAbstractFileById(this.artifact.getObjectID()).getName();
+            } catch (TskCoreException | NoCurrentCaseException ex) {
+                displayName = artifact.getName();
+            }
         }
 
         this.setDisplayName(displayName);


### PR DESCRIPTION
Get file name instead of artifact name for when you hover over the artifact