### PR TITLE
5342-Create-artifacts-for-recently-used-Windows-Media-Player-files-from-regripper-output

### DIFF
--- a/RecentActivity/src/org/sleuthkit/autopsy/recentactivity/ExtractRegistry.java
+++ b/RecentActivity/src/org/sleuthkit/autopsy/recentactivity/ExtractRegistry.java
@@ -1244,7 +1244,7 @@ class ExtractRegistry extends Extract {
     }
     
      /**
-     * Create recently used artifacts from mpmru records
+     * Create recently used artifacts to parse the mpmru records
      * 
      * @param regFileName name of the regripper output file
      * 


### PR DESCRIPTION
Add mpmru parsing, change where artifacts are added in adobemru so it does not get checked every time.