### PR TITLE
Update installation instructions for macOS

### DIFF
--- a/Running_Linux_OSX.txt
+++ b/Running_Linux_OSX.txt
@@ -27,7 +27,7 @@ The following need to be done at least once. They do not need to be repeated for
 -- OS X:
     1. Install BellSoft Java 8.
         % brew tap bell-sw/liberica
-        % brew cask install liberica-jdk8
+        % brew cask install liberica-jdk8-full
     2. Set JAVA_HOME environment variable to location of JRE installation.
        e.g. add the following to ~/.bashrc
            export JAVA_HOME=$(/usr/libexec/java_home -v 1.8)


### PR DESCRIPTION
On macOS one has to install the `liberica-jdk8-full` package in order to have OpenJFX.

The `liberica-jdk8` package **does not work correctly with Autopsy.**