### PR TITLE
6571-Change-color-in-Geolocation-so-GPS-Route-and-EXIF-Metadata-are-different

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/geolocation/MapWaypoint.java
+++ b/Core/src/org/sleuthkit/autopsy/geolocation/MapWaypoint.java
@@ -78,7 +78,7 @@ final class MapWaypoint extends KdTree.XYZPoint implements org.jxmapviewer.viewe
         artifactTypesToColors.put(BlackboardArtifact.ARTIFACT_TYPE.TSK_GPS_SEARCH.getTypeID(), Color.GREEN);
         artifactTypesToColors.put(BlackboardArtifact.ARTIFACT_TYPE.TSK_GPS_TRACK.getTypeID(), Color.ORANGE);
         artifactTypesToColors.put(BlackboardArtifact.ARTIFACT_TYPE.TSK_GPS_TRACKPOINT.getTypeID(), Color.ORANGE);
-        artifactTypesToColors.put(BlackboardArtifact.ARTIFACT_TYPE.TSK_METADATA_EXIF.getTypeID(), Color.CYAN);
+        artifactTypesToColors.put(BlackboardArtifact.ARTIFACT_TYPE.TSK_METADATA_EXIF.getTypeID(), Color.MAGENTA);
     }
 
     private final Waypoint dataModelWaypoint;


### PR DESCRIPTION
Change colr for TSK_METADATA_EXIF from cyan to Magenta