### PR TITLE
Bug fix for HEICProcessor

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/modules/pictureanalyzer/impls/HEICProcessor.java
+++ b/Core/src/org/sleuthkit/autopsy/modules/pictureanalyzer/impls/HEICProcessor.java
@@ -182,6 +182,7 @@ public class HEICProcessor implements PictureProcessor {
         final Path outputFile = moduleOutputFolder.resolve(baseFileName + ".jpg");
         
         final Path imageMagickErrorOutput = moduleOutputFolder.resolve(IMAGE_MAGICK_ERROR_FILE);
+        Files.deleteIfExists(imageMagickErrorOutput);
         Files.createFile(imageMagickErrorOutput);
 
         // ImageMagick will write the primary image to the output file.


### PR DESCRIPTION
There is a bug when ingesting a data source more than once. For each file, the processor redirects ImageMagick error output to the file's module output directory. Multiple runs result in a FileAlreadyExistsException. Re-running the module should just delete this output file if it exists, since the output file needs to reflect the most recent run.