### PR TITLE
6924-Error-parsing-output-of-custom-Autopsy-RegRipper-plugins

### DIFF
--- a/thirdparty/rr/plugins/autopsyusb.pl
+++ b/thirdparty/rr/plugins/autopsyusb.pl
@@ -100,13 +100,13 @@ sub pluginmain {
 			}
 		}
 		else {
-			::rptMsg($key_path." has no subkeys.");
+			#::rptMsg($key_path." has no subkeys.");
 			#::logMsg($key_path." has no subkeys.");
 		}
 		::rptMsg("</artifacts></usb>");
 	}
 	else {
-		::rptMsg($key_path." not found.");
+		#::rptMsg($key_path." not found.");
 		#::logMsg($key_path." not found.");
 	}
 }


### PR DESCRIPTION
Comment out lines that issue errors as they are not needed in the file.