### PR TITLE
7044-duplicate-prefetch-entries

### DIFF
--- a/RecentActivity/src/org/sleuthkit/autopsy/recentactivity/ExtractPrefetch.java
+++ b/RecentActivity/src/org/sleuthkit/autopsy/recentactivity/ExtractPrefetch.java
@@ -286,14 +286,12 @@ final class ExtractPrefetch extends Extract {
                                         BlackboardAttribute.ATTRIBUTE_TYPE.TSK_COMMENT, getName(), PREFETCH_TSK_COMMENT));
 
                         try {
-                            if (!blackboard.artifactExists(dataSource, BlackboardArtifact.ARTIFACT_TYPE.TSK_PROG_RUN, blkBrdAttributes)) {
-                                BlackboardArtifact blkBrdArt = pfAbstractFile.newArtifact(BlackboardArtifact.ARTIFACT_TYPE.TSK_PROG_RUN);
-                                blkBrdArt.addAttributes(blkBrdAttributes);
-                                blkBrdArtList.add(blkBrdArt);
-                                BlackboardArtifact associatedBbArtifact = createAssociatedArtifact(applicationName.toLowerCase(), filePath, blkBrdArt, dataSource);
-                                if (associatedBbArtifact != null) {
-                                    blkBrdArtList.add(associatedBbArtifact);
-                                }
+                            BlackboardArtifact blkBrdArt = pfAbstractFile.newArtifact(BlackboardArtifact.ARTIFACT_TYPE.TSK_PROG_RUN);
+                            blkBrdArt.addAttributes(blkBrdAttributes);
+                            blkBrdArtList.add(blkBrdArt);
+                            BlackboardArtifact associatedBbArtifact = createAssociatedArtifact(applicationName.toLowerCase(), filePath, blkBrdArt, dataSource);
+                            if (associatedBbArtifact != null) {
+                                blkBrdArtList.add(associatedBbArtifact);
                             }
                         } catch (TskCoreException ex) {
                             logger.log(Level.SEVERE, "Exception Adding Artifact.", ex);//NON-NLS

--- a/RecentActivity/src/org/sleuthkit/autopsy/recentactivity/ExtractPrefetch.java
+++ b/RecentActivity/src/org/sleuthkit/autopsy/recentactivity/ExtractPrefetch.java
@@ -29,11 +29,14 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
 import org.openide.modules.InstalledFileLocator;
 import org.openide.util.NbBundle.Messages;
 import org.sleuthkit.autopsy.casemodule.Case;
+import org.sleuthkit.autopsy.casemodule.NoCurrentCaseException;
 import org.sleuthkit.autopsy.casemodule.services.FileManager;
 import org.sleuthkit.autopsy.coreutils.ExecUtil;
 import org.sleuthkit.autopsy.coreutils.Logger;
@@ -262,7 +265,7 @@ final class ExtractPrefetch extends Extract {
 
                 AbstractFile pfAbstractFile = getAbstractFile(prefetchFileName, PREFETCH_FILE_LOCATION, dataSource);
 
-                List<Long> prefetchExecutionTimes = findNonZeroExecutionTimes(executionTimes);
+                Set<Long> prefetchExecutionTimes = findNonZeroExecutionTimes(executionTimes);
 
                 if (pfAbstractFile != null) {
                     for (Long executionTime : prefetchExecutionTimes) {
@@ -283,12 +286,14 @@ final class ExtractPrefetch extends Extract {
                                         BlackboardAttribute.ATTRIBUTE_TYPE.TSK_COMMENT, getName(), PREFETCH_TSK_COMMENT));
 
                         try {
-                            BlackboardArtifact blkBrdArt = pfAbstractFile.newArtifact(BlackboardArtifact.ARTIFACT_TYPE.TSK_PROG_RUN);
-                            blkBrdArt.addAttributes(blkBrdAttributes);
-                            blkBrdArtList.add(blkBrdArt);
-                            BlackboardArtifact associatedBbArtifact = createAssociatedArtifact(applicationName.toLowerCase(), filePath, blkBrdArt, dataSource);
-                            if (associatedBbArtifact != null) {
-                                blkBrdArtList.add(associatedBbArtifact);
+                            if (!blackboard.artifactExists(dataSource, BlackboardArtifact.ARTIFACT_TYPE.TSK_PROG_RUN, blkBrdAttributes)) {
+                                BlackboardArtifact blkBrdArt = pfAbstractFile.newArtifact(BlackboardArtifact.ARTIFACT_TYPE.TSK_PROG_RUN);
+                                blkBrdArt.addAttributes(blkBrdAttributes);
+                                blkBrdArtList.add(blkBrdArt);
+                                BlackboardArtifact associatedBbArtifact = createAssociatedArtifact(applicationName.toLowerCase(), filePath, blkBrdArt, dataSource);
+                                if (associatedBbArtifact != null) {
+                                    blkBrdArtList.add(associatedBbArtifact);
+                                }
                             }
                         } catch (TskCoreException ex) {
                             logger.log(Level.SEVERE, "Exception Adding Artifact.", ex);//NON-NLS
@@ -321,8 +326,8 @@ final class ExtractPrefetch extends Extract {
      *
      * @return List of timestamps that are greater than zero
      */
-    private List<Long> findNonZeroExecutionTimes(List<Long> executionTimes) {
-        List<Long> prefetchExecutionTimes = new ArrayList<>();
+    private Set<Long> findNonZeroExecutionTimes(List<Long> executionTimes) {
+        Set<Long> prefetchExecutionTimes = new HashSet<>();
         for (Long executionTime : executionTimes) {                        // only add prefetch file entries that have an actual date associated with them
             if (executionTime > 0) {
                 prefetchExecutionTimes.add(executionTime);


### PR DESCRIPTION
Change Collection type from list to set avoid duplicate timestamps.  Added check to see if artifact already exists before tryng to add it back in, this will help with reruns of RA.