### PR TITLE
[MultiUserTestTool] fix for wrong created temporary file

### DIFF
--- a/Experimental/src/org/sleuthkit/autopsy/experimental/configuration/MultiUserTestTool.java
+++ b/Experimental/src/org/sleuthkit/autopsy/experimental/configuration/MultiUserTestTool.java
@@ -153,7 +153,7 @@ class MultiUserTestTool {
                 return Bundle.MultiUserTestTool_unableToReadDatabase() + ". " + ex.getMessage();
             }
 
-            // Make a text file in Windows TEMP folder 
+            // Make a text file in TEMP folder
             Path tempFilePath = Paths.get(System.getProperty("java.io.tmpdir"), TEST_FILE_NAME + "_" + TimeStampUtils.createTimeStamp() + ".txt");
             try {
                 FileUtils.writeStringToFile(tempFilePath.toFile(), "Test", Charset.forName("UTF-8"));

--- a/Experimental/src/org/sleuthkit/autopsy/experimental/configuration/MultiUserTestTool.java
+++ b/Experimental/src/org/sleuthkit/autopsy/experimental/configuration/MultiUserTestTool.java
@@ -23,6 +23,7 @@ import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -153,16 +154,16 @@ class MultiUserTestTool {
             }
 
             // Make a text file in Windows TEMP folder 
-            String tempFilePath = System.getProperty("java.io.tmpdir") + TEST_FILE_NAME + "_" + TimeStampUtils.createTimeStamp() + ".txt";
+            Path tempFilePath = Paths.get(System.getProperty("java.io.tmpdir"), TEST_FILE_NAME + "_" + TimeStampUtils.createTimeStamp() + ".txt");
             try {
-                FileUtils.writeStringToFile(new File(tempFilePath), "Test", Charset.forName("UTF-8"));
+                FileUtils.writeStringToFile(tempFilePath.toFile(), "Test", Charset.forName("UTF-8"));
             } catch (IOException ex) {
                 LOGGER.log(Level.SEVERE, Bundle.MultiUserTestTool_unableCreatFile(), ex);
                 return Bundle.MultiUserTestTool_unableCreatFile() + ". " + ex.getMessage();
             }
 
             //  Add it as a logical file set data source.
-            AutoIngestDataSource dataSource = new AutoIngestDataSource("", Paths.get(tempFilePath));
+            AutoIngestDataSource dataSource = new AutoIngestDataSource("", tempFilePath);
             try {
                 String error = runLogicalFilesDSP(caseForJob, dataSource);
                 if (!error.isEmpty()) {
@@ -178,7 +179,7 @@ class MultiUserTestTool {
             FileManager fileManager = caseForJob.getServices().getFileManager();
             List<AbstractFile> listOfFiles = null;
             try {
-                listOfFiles = fileManager.findFiles(new File(tempFilePath).getName());
+                listOfFiles = fileManager.findFiles(tempFilePath.toFile().getName());
                 if (listOfFiles == null || listOfFiles.isEmpty()) {
                     LOGGER.log(Level.SEVERE, Bundle.MultiUserTestTool_unableToReadTestFileFromDatabase());
                     return Bundle.MultiUserTestTool_unableToReadTestFileFromDatabase();


### PR DESCRIPTION
Hello,

after setting up a multi user environment in Linux the test fails and tells me that I have insufficient privileges to create a file.

I tracked the error down when the `MultiUserTestTool` class is creating a temporary file: https://github.com/sleuthkit/autopsy/blob/4c66d9b4e610c3d462dd3a16ba8f4fba36fc4220/Experimental/src/org/sleuthkit/autopsy/experimental/configuration/MultiUserTestTool.java#L156
The problem is that at least in Linux the environment variable `java.io.tmpdir` contains by default the string: `"/tmp"`
That means the concatenation will create a string like that:
`String tempFilePath = "/tmpAutopsyTempFile_<timestamp>.txt"`
So autopsy tries to create a file in the root directory `/`. But the file should be created in the `/tmp` directory.

With my fix there's a `java.nio.file.Path` object is created, which is more platform independent. An object of this type is created later anyway.