### PR TITLE
Added JAVA_HOME variable

### DIFF
--- a/unix_setup.sh
+++ b/unix_setup.sh
@@ -6,6 +6,7 @@
 # NOTE: update_sleuthkit_version.pl updates this value and relies
 # on it keeping the same name and whitespace.  Don't change it.
 TSK_VERSION=4.10.1
+JAVA_HOME=$(readlink -f /usr/bin/javac | sed "s:/bin/javac::")
 
 
 # In the beginning...


### PR DESCRIPTION
Script is not detecting JAVA_HOME on own and showing error 
`Checking for Java...ERROR: JAVA_HOME environment variable must be defined.`

And running autopsy without setting JAVA_HOME leading to issue 
[Issue #3829](https://github.com/sleuthkit/autopsy/issues/3829)