### PR TITLE
update brew cask install to brew install --cask

### DIFF
--- a/Running_Linux_OSX.txt
+++ b/Running_Linux_OSX.txt
@@ -64,7 +64,7 @@ The following need to be done at least once. They do not need to be repeated for
 -- OS X:
     1. Install BellSoft Java 8.
         % brew tap bell-sw/liberica
-        % brew cask install liberica-jdk8-full
+        % brew install --cask liberica-jdk8-full
     2. Set JAVA_HOME environment variable to location of JRE installation.
        e.g. add the following to ~/.bashrc
            export JAVA_HOME=$(/usr/libexec/java_home -v 1.8)

--- a/Running_Linux_OSX.txt
+++ b/Running_Linux_OSX.txt
@@ -64,7 +64,10 @@ The following need to be done at least once. They do not need to be repeated for
 -- OS X:
     1. Install BellSoft Java 8.
         % brew tap bell-sw/liberica
-        % brew install --cask liberica-jdk8-full
+        for macOS BigSur and later:
+             % brew install --cask liberica-jdk8-full
+        for macOS versions before BigSur:
+             % brew cask install liberica-jdk8-full
     2. Set JAVA_HOME environment variable to location of JRE installation.
        e.g. add the following to ~/.bashrc
            export JAVA_HOME=$(/usr/libexec/java_home -v 1.8)


### PR DESCRIPTION
For MacOS in 2021:
brew cask install is no longer valid and has since been replaced with brew install --cask 

check https://brew.sh