### PR TITLE
7098-BufferUnderflowException-in-Chromium-sub-module-of-Recent-Activity-module

### DIFF
--- a/RecentActivity/src/org/sleuthkit/autopsy/recentactivity/ChromeCacheExtractor.java
+++ b/RecentActivity/src/org/sleuthkit/autopsy/recentactivity/ChromeCacheExtractor.java
@@ -283,7 +283,9 @@ final class ChromeCacheExtractor {
                     return;
                 }
                 
-                processCacheFolder(indexFile);
+                if (indexFile.getSize() > 0) {
+                    processCacheFolder(indexFile);
+                }
             }
         
         } catch (TskCoreException ex) {


### PR DESCRIPTION
Check if a zero byte file and do not process it, if it is.