### PR TITLE
unit test fixes for changes in blackboard artifact type constructors

### DIFF
--- a/Core/test/unit/src/org/sleuthkit/autopsy/datasourcesummary/datamodel/DataSourceInfoUtilitiesTest.java
+++ b/Core/test/unit/src/org/sleuthkit/autopsy/datasourcesummary/datamodel/DataSourceInfoUtilitiesTest.java
@@ -287,7 +287,7 @@ public class DataSourceInfoUtilitiesTest {
     @Test
     public void getArtifacts_failOnBytes() throws TskCoreException {
         testFailOnBadAttrType(
-                new BlackboardArtifact.Type(999, "BYTE_ARRAY_TYPE", "Byte Array Type", BlackboardArtifact.Category.DATA_ARTIFACT),
+                BlackboardArtifact.Type.TSK_YARA_HIT,
                 new BlackboardAttribute.Type(999, "BYTE_ARR_ATTR_TYPE", "Byte Array Attribute Type", TSK_BLACKBOARD_ATTRIBUTE_VALUE_TYPE.BYTE),
                 new byte[]{0x0, 0x1, 0x2},
                 BlackboardAttribute::new);

--- a/Core/test/unit/src/org/sleuthkit/autopsy/datasourcesummary/datamodel/UserActivitySummaryTest.java
+++ b/Core/test/unit/src/org/sleuthkit/autopsy/datasourcesummary/datamodel/UserActivitySummaryTest.java
@@ -353,7 +353,7 @@ public class UserActivitySummaryTest {
         List<TopDeviceAttachedResult> results = summary.getRecentDevices(dataSource, 10);
 
         Assert.assertEquals(1, results.size());
-        Assert.assertEquals((long) (DAY_SECONDS + 2), results.get(0).getLastAccessed().getTime() / 1000);
+        Assert.assertEquals((DAY_SECONDS + 2), results.get(0).getLastAccessed().getTime() / 1000);
         Assert.assertTrue("ID1".equalsIgnoreCase(results.get(0).getDeviceId()));
         Assert.assertTrue("MAKE1".equalsIgnoreCase(results.get(0).getDeviceMake()));
         Assert.assertTrue("MODEL1".equalsIgnoreCase(results.get(0).getDeviceModel()));


### PR DESCRIPTION
I also removed the `(long)` cast to remove a warning.