### PR TITLE
fix-duplicate-interesting-hits-cr-osaccounts

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/centralrepository/eventlisteners/CaseEventListener.java
+++ b/Core/src/org/sleuthkit/autopsy/centralrepository/eventlisteners/CaseEventListener.java
@@ -729,6 +729,7 @@ public final class CaseEventListener implements PropertyChangeListener {
                                 try {
                                     // index the artifact for keyword search
                                     blackboard.postArtifact(newAnalysisResult, MODULE_NAME);
+                                    break;
                                 } catch (Blackboard.BlackboardException ex) {
                                     LOGGER.log(Level.SEVERE, "Unable to index blackboard artifact " + newAnalysisResult.getArtifactID(), ex); //NON-NLS
                                 }


### PR DESCRIPTION
Add break statement to only get the first occurence in the CR