### PR TITLE
7824-Illegal-character-reported-in-Recent-Activity

### DIFF
--- a/RecentActivity/src/org/sleuthkit/autopsy/recentactivity/ExtractPrefetch.java
+++ b/RecentActivity/src/org/sleuthkit/autopsy/recentactivity/ExtractPrefetch.java
@@ -116,9 +116,9 @@ final class ExtractPrefetch extends Extract {
             return;
         }
 
-        String modOutFile = modOutPath + File.separator + dataSource.getName() + "-" + PREFETCH_PARSER_DB_FILE;
+        String modOutFile = modOutPath + File.separator + dataSource.getId() + "-" + PREFETCH_PARSER_DB_FILE;
         try {
-            String tempDirPath = RAImageIngestModule.getRATempPath(Case.getCurrentCase(), dataSource.getName() + "-" + PREFETCH_DIR_NAME, ingestJobId);
+            String tempDirPath = RAImageIngestModule.getRATempPath(Case.getCurrentCase(), dataSource.getId() + "-" + PREFETCH_DIR_NAME, ingestJobId);
             parsePrefetchFiles(prefetchDumper, tempDirPath, modOutFile, modOutPath);
             File prefetchDatabase = new File(modOutFile);
             if (prefetchDatabase.exists()) {


### PR DESCRIPTION
Changed dataSource.getName() to dataSource.getId() to avoid any illegal characters when using a local disk as a datasource