### PR TITLE
8008-IllegalArgumentException-in-RA-ExtractZoneIdentifier-module

### DIFF
--- a/RecentActivity/src/org/sleuthkit/autopsy/recentactivity/ExtractZoneIdentifier.java
+++ b/RecentActivity/src/org/sleuthkit/autopsy/recentactivity/ExtractZoneIdentifier.java
@@ -318,7 +318,13 @@ final class ExtractZoneIdentifier extends Extract {
          */
         ZoneIdentifierInfo(AbstractFile zoneFile) throws IOException {
             fileName = zoneFile.getName();
-            properties.load(new ReadContentInputStream(zoneFile));
+            // properties.load will throw IllegalArgument if unicode characters are found in the zone file.
+            try {
+                properties.load(new ReadContentInputStream(zoneFile));
+            } catch (IllegalArgumentException ex) {
+                String message = String.format("Unable to parse Zone Id for File %s", fileName); //NON-NLS
+                LOG.log(Level.WARNING, message);   
+            }
         }
 
         /**


### PR DESCRIPTION
Try catch for IllegalArgument when it is thrown.  log message and continue on processing