### PR TITLE
linux_macos_install_scripts: allows installing tsk in a empty directory

### DIFF
--- a/linux_macos_install_scripts/install_tsk_from_src.sh
+++ b/linux_macos_install_scripts/install_tsk_from_src.sh
@@ -34,7 +34,7 @@ if [[ -z "${SLEUTHKIT_SRC_DIR}" ]]; then
     exit 1
 fi
 
-if [[ ! -d $SLEUTHKIT_SRC_DIR ]]; then
+if [[ ! -d $SLEUTHKIT_SRC_DIR/.git ]]; then
     TSK_REPO_PATH=$(dirname "$SLEUTHKIT_SRC_DIR")
     echo "Cloning Sleuthkit to $TSK_REPO_PATH..."
     mkdir -p $TSK_REPO_PATH &&


### PR DESCRIPTION
If the target directory of `linux_macos_install_scripts/install_tsk_from_src.sh` was an empty directory, previously a "not a git repository" error would occur. This PR resolves this.