### PR TITLE
Add data artifact extension point to query for additional property sheets (for Cyber Triage Data)

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,101 @@
+name: Build Autopsy on Windows
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  TSK_HOME: "C:\\sleuthkit"
+  PLATFORM_REL_DIR: "netbeans-plat/15"
+  HARNESS_REL_DIR: "netbeans-plat/15/harness"
+
+jobs:
+  build:
+    runs-on: windows-2025
+
+    steps:
+      - name: Checkout Autopsy
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+
+      - name: Set JDK_HOME
+        shell: bash
+        run: |
+          echo "JDK_HOME=$JAVA_HOME" >> $GITHUB_ENV
+          echo "INCLUDE=$INCLUDE;$JAVA_HOME/include;$JAVA_HOME/include/win32" >> $GITHUB_ENV
+
+      - name: Cache Chocolatey packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            C:\ProgramData\chocolatey\bin
+            C:\ProgramData\chocolatey\lib
+          key: choco-nuget-ant
+
+      - name: Install nuget and ant
+        run: |
+          choco install nuget.commandline
+          choco install ant --ignore-dependencies
+
+      - name: Clone SleuthKit
+        run: |
+          git clone --branch develop-4.14 https://github.com/sleuthkit/sleuthkit C:\sleuthkit
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: C:\sleuthkit\win32\packages
+          key: nuget-${{ hashFiles('C:\sleuthkit\win32\libtsk\packages.config') }}
+          restore-keys: nuget-
+
+      - name: Build SleuthKit native libraries
+        working-directory: C:\sleuthkit
+        run: |
+          nuget restore win32\libtsk -PackagesDirectory win32\packages
+          python win32\updateAndBuildAll.py -m
+
+      - name: Build SleuthKit Java bindings
+        working-directory: C:\sleuthkit\bindings\java
+        run: |
+          ant -version
+          ant dist
+
+      - name: Build case-uco Java
+        working-directory: C:\sleuthkit\case-uco\java
+        run: |
+          ant -q
+
+      - name: Build Autopsy
+        run: >-
+          ant -q
+          -Dnbplatform.active.dir="${{ github.workspace }}/${{ env.PLATFORM_REL_DIR }}"
+          -Dnbplatform.default.harness.dir="${{ github.workspace }}/${{ env.HARNESS_REL_DIR }}"
+          build
+
+      - name: Run Core unit tests
+        run: >-
+          ant -f "${{ github.workspace }}/Core/build.xml"
+          -Dnbplatform.active.dir="${{ github.workspace }}/${{ env.PLATFORM_REL_DIR }}"
+          -Dnbplatform.default.harness.dir="${{ github.workspace }}/${{ env.HARNESS_REL_DIR }}"
+          test-unit
+
+      - name: Run KeywordSearch unit tests
+        run: >-
+          ant -f "${{ github.workspace }}/KeywordSearch/build.xml"
+          -Dnbplatform.active.dir="${{ github.workspace }}/${{ env.PLATFORM_REL_DIR }}"
+          -Dnbplatform.default.harness.dir="${{ github.workspace }}/${{ env.HARNESS_REL_DIR }}"
+          test-unit

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -14,7 +14,7 @@ concurrency:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  TSK_HOME: "C:\\sleuthkit"
+  TSK_HOME: "${{ github.workspace }}\\sleuthkit"
   PLATFORM_REL_DIR: "netbeans-plat/15"
   HARNESS_REL_DIR: "netbeans-plat/15/harness"
 
@@ -48,54 +48,54 @@ jobs:
 
       - name: Install nuget and ant
         run: |
-          choco install nuget.commandline
-          choco install ant --ignore-dependencies
+          choco install nuget.commandline -y
+          choco install ant --ignore-dependencies -y
 
       - name: Clone SleuthKit
         run: |
-          git clone --branch develop-4.14 https://github.com/sleuthkit/sleuthkit C:\sleuthkit
+          git clone --branch develop-4.14 https://github.com/sleuthkit/sleuthkit "${{ github.workspace }}\sleuthkit"
 
       - name: Cache NuGet packages
         uses: actions/cache@v4
         with:
-          path: C:\sleuthkit\win32\packages
-          key: nuget-${{ hashFiles('C:\sleuthkit\win32\libtsk\packages.config') }}
+          path: ${{ github.workspace }}\sleuthkit\win32\packages
+          key: nuget-${{ hashFiles('sleuthkit/win32/libtsk/packages.config') }}
           restore-keys: nuget-
 
       - name: Build SleuthKit native libraries
-        working-directory: C:\sleuthkit
+        working-directory: ${{ github.workspace }}\sleuthkit
         run: |
           nuget restore win32\libtsk -PackagesDirectory win32\packages
           python win32\updateAndBuildAll.py -m
 
       - name: Build SleuthKit Java bindings
-        working-directory: C:\sleuthkit\bindings\java
+        working-directory: ${{ github.workspace }}\sleuthkit\bindings\java
         run: |
           ant -version
           ant dist
 
       - name: Build case-uco Java
-        working-directory: C:\sleuthkit\case-uco\java
+        working-directory: ${{ github.workspace }}\sleuthkit\case-uco\java
         run: |
           ant -q
 
       - name: Build Autopsy
         run: >-
           ant -q
-          -Dnbplatform.active.dir="${{ github.workspace }}/${{ env.PLATFORM_REL_DIR }}"
-          -Dnbplatform.default.harness.dir="${{ github.workspace }}/${{ env.HARNESS_REL_DIR }}"
+          -Dnbplatform.download.netbeans.dest.dir="${{ github.workspace }}/${{ env.PLATFORM_REL_DIR }}"
+          -Dnbplatform.download.harness.dir="${{ github.workspace }}/${{ env.HARNESS_REL_DIR }}"
           build
 
       - name: Run Core unit tests
         run: >-
           ant -f "${{ github.workspace }}/Core/build.xml"
-          -Dnbplatform.active.dir="${{ github.workspace }}/${{ env.PLATFORM_REL_DIR }}"
-          -Dnbplatform.default.harness.dir="${{ github.workspace }}/${{ env.HARNESS_REL_DIR }}"
+          -Dnbplatform.download.netbeans.dest.dir="${{ github.workspace }}/${{ env.PLATFORM_REL_DIR }}"
+          -Dnbplatform.download.harness.dir="${{ github.workspace }}/${{ env.HARNESS_REL_DIR }}"
           test-unit
 
       - name: Run KeywordSearch unit tests
         run: >-
           ant -f "${{ github.workspace }}/KeywordSearch/build.xml"
-          -Dnbplatform.active.dir="${{ github.workspace }}/${{ env.PLATFORM_REL_DIR }}"
-          -Dnbplatform.default.harness.dir="${{ github.workspace }}/${{ env.HARNESS_REL_DIR }}"
+          -Dnbplatform.download.netbeans.dest.dir="${{ github.workspace }}/${{ env.PLATFORM_REL_DIR }}"
+          -Dnbplatform.download.harness.dir="${{ github.workspace }}/${{ env.HARNESS_REL_DIR }}"
           test-unit

--- a/Core/src/org/sleuthkit/autopsy/datamodel/ArtifactPropertyEnricher.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/ArtifactPropertyEnricher.java
@@ -42,6 +42,11 @@ public interface ArtifactPropertyEnricher {
      * Implementations must be efficient: this is called on every node
      * expansion. Results should be cached where appropriate.
      *
+     * The returned Sheet.Set must have a name that does not conflict with any
+     * set already present in the sheet (e.g., Sheet.PROPERTIES). If a
+     * duplicate name is detected at runtime the set will be skipped and a
+     * warning logged.
+     *
      * @param artifact The artifact whose property sheet is being built.
      *
      * @return A Sheet.Set to append, or null if none.

--- a/Core/src/org/sleuthkit/autopsy/datamodel/ArtifactPropertyEnricher.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/ArtifactPropertyEnricher.java
@@ -1,7 +1,7 @@
 /*
- * Autopsy Forensic Browser
+ * Autopsy 
  *
- * Copyright 2025 Basis Technology Corp.
+ * Copyright 2026 Sleuth Kit Labs
  * Contact: carrier <at> sleuthkit <dot> org
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/Core/src/org/sleuthkit/autopsy/datamodel/ArtifactPropertyEnricher.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/ArtifactPropertyEnricher.java
@@ -1,0 +1,53 @@
+/*
+ * Autopsy Forensic Browser
+ *
+ * Copyright 2025 Basis Technology Corp.
+ * Contact: carrier <at> sleuthkit <dot> org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sleuthkit.autopsy.datamodel;
+
+import org.openide.nodes.Sheet;
+import org.sleuthkit.datamodel.BlackboardArtifact;
+import org.sleuthkit.datamodel.TskCoreException;
+
+/**
+ * Extension point for adding supplemental property sheet sections to
+ * BlackboardArtifactNode. Implementations are discovered via the global
+ * NetBeans Lookup and should be registered with @ServiceProvider.
+ *
+ * Example registration in the implementing module:
+ * <pre>
+ *   {@literal @}ServiceProvider(service = ArtifactPropertyEnricher.class)
+ *   public class MyEnricher implements ArtifactPropertyEnricher { ... }
+ * </pre>
+ */
+public interface ArtifactPropertyEnricher {
+
+    /**
+     * Returns an additional Sheet.Set to append to the property sheet for the
+     * given artifact, or null if this enricher has no supplemental data for it.
+     *
+     * Implementations must be efficient: this is called on every node
+     * expansion. Results should be cached where appropriate.
+     *
+     * @param artifact The artifact whose property sheet is being built.
+     *
+     * @return A Sheet.Set to append, or null if none.
+     *
+     * @throws TskCoreException If there is an error accessing the case
+     *                          database.
+     */
+    Sheet.Set getEnrichment(BlackboardArtifact artifact) throws TskCoreException;
+}

--- a/Core/src/org/sleuthkit/autopsy/datamodel/BlackboardArtifactNode.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/BlackboardArtifactNode.java
@@ -1,7 +1,7 @@
 /*
- * Autopsy Forensic Browser
+ * Autopsy 
  *
- * Copyright 2012-2021 Basis Technology Corp.
+ * Copyright 2012-2026 Sleuth Kit Labs
  * Contact: carrier <at> sleuthkit <dot> org
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/Core/src/org/sleuthkit/autopsy/datamodel/BlackboardArtifactNode.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/BlackboardArtifactNode.java
@@ -1150,6 +1150,17 @@ public class BlackboardArtifactNode extends AbstractContentNode<BlackboardArtifa
             backgroundTasksPool.submit(scoTask);
         }
 
+        for (ArtifactPropertyEnricher enricher : Lookup.getDefault().lookupAll(ArtifactPropertyEnricher.class)) {
+            try {
+                Sheet.Set enrichmentSet = enricher.getEnrichment(artifact);
+                if (enrichmentSet != null) {
+                    sheet.put(enrichmentSet);
+                }
+            } catch (TskCoreException ex) {
+                logger.log(Level.WARNING, String.format("Error getting property enrichment for artifact %d", artifact.getArtifactID()), ex);
+            }
+        }
+
         return sheet;
     }
 

--- a/Core/src/org/sleuthkit/autopsy/datamodel/BlackboardArtifactNode.java
+++ b/Core/src/org/sleuthkit/autopsy/datamodel/BlackboardArtifactNode.java
@@ -1154,10 +1154,16 @@ public class BlackboardArtifactNode extends AbstractContentNode<BlackboardArtifa
             try {
                 Sheet.Set enrichmentSet = enricher.getEnrichment(artifact);
                 if (enrichmentSet != null) {
-                    sheet.put(enrichmentSet);
+                    if (sheet.get(enrichmentSet.getName()) != null) {
+                        logger.log(Level.WARNING, String.format("Enricher %s returned a Sheet.Set with duplicate name '%s' for artifact %d; skipping to avoid overwriting existing properties",
+                                enricher.getClass().getName(), enrichmentSet.getName(), artifact.getArtifactID()));
+                    } else {
+                        sheet.put(enrichmentSet);
+                    }
                 }
-            } catch (TskCoreException ex) {
-                logger.log(Level.WARNING, String.format("Error getting property enrichment for artifact %d", artifact.getArtifactID()), ex);
+            } catch (Exception ex) {
+                logger.log(Level.WARNING, String.format("Error getting property enrichment from %s for artifact %d",
+                        enricher.getClass().getName(), artifact.getArtifactID()), ex);
             }
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Artifact property sheets can be extended by registered enrichment modules to show additional contextual information.

* **Bug Fixes / Improvements**
  * Enrichment failures are caught and logged to avoid breaking property sheet display.
  * Enrichments that would conflict with existing sections are skipped and logged instead of overwriting.

* **Chores**
  * Added a Windows CI workflow to build and test the project on Windows runners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->