### PR TITLE
Added checks to bail out of iLeap and aLeap modules faster

### DIFF
--- a/Core/src/org/sleuthkit/autopsy/modules/leappanalyzers/ALeappAnalyzerIngestModule.java
+++ b/Core/src/org/sleuthkit/autopsy/modules/leappanalyzers/ALeappAnalyzerIngestModule.java
@@ -28,6 +28,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Locale;
@@ -54,9 +55,12 @@ import org.sleuthkit.autopsy.ingest.IngestServices;
 import org.sleuthkit.autopsy.ingest.IngestModule.IngestModuleException;
 import org.sleuthkit.datamodel.AbstractFile;
 import org.sleuthkit.datamodel.Content;
+import org.sleuthkit.datamodel.FileSystem;
+import org.sleuthkit.datamodel.Image;
 import org.sleuthkit.datamodel.LocalFilesDataSource;
 import org.sleuthkit.datamodel.ReadContentInputStream;
 import org.sleuthkit.datamodel.TskCoreException;
+import org.sleuthkit.datamodel.TskData;
 
 /**
  * Data source ingest module that runs aLeapp against logical iOS files.
@@ -72,6 +76,13 @@ public class ALeappAnalyzerIngestModule implements DataSourceIngestModule {
     private static final String ALEAPP_PATHS_FILE = "aLeapp_paths.txt"; //NON-NLS
 
     private static final String XMLFILE = "aleapp-artifact-attribute-reference.xml"; //NON-NLS
+
+    // Android-specific files used to detect whether the data source is from an Android device.
+    // Filename and parent-path pairs searched in order; finding any one is sufficient.
+    private static final List<String[]> ANDROID_INDICATOR_FILES = Arrays.asList(
+            new String[]{"build.prop", "/system/"},                                               //NON-NLS
+            new String[]{"packages.xml", "/data/system/"},                                        //NON-NLS
+            new String[]{"settings.db", "/data/com.android.providers.settings/databases/"});      //NON-NLS
 
     private File aLeappExecutable;
 
@@ -122,9 +133,18 @@ public class ALeappAnalyzerIngestModule implements DataSourceIngestModule {
         "ALeappAnalyzerIngestModule.has.run=aLeapp",
         "ALeappAnalyzerIngestModule.aLeapp.cancelled=aLeapp run was canceled",
         "ALeappAnalyzerIngestModule.completed=aLeapp Processing Completed",
-        "ALeappAnalyzerIngestModule.report.name=aLeapp Html Report"})
+        "ALeappAnalyzerIngestModule.report.name=aLeapp Html Report",
+        "ALeappAnalyzerIngestModule.notAndroid.skipped=aLeapp skipped: data source does not appear to be an Android device."})
     @Override
     public ProcessResult process(Content dataSource, DataSourceIngestModuleProgress statusHelper) {
+
+        if (!isAndroidDataSource(dataSource)) {
+            logger.log(Level.INFO, "aLeapp: data source does not appear to be Android, skipping."); //NON-NLS
+            IngestMessage message = IngestMessage.createMessage(IngestMessage.MessageType.DATA,
+                    MODULE_NAME, Bundle.ALeappAnalyzerIngestModule_notAndroid_skipped());
+            IngestServices.getInstance().postMessage(message);
+            return ProcessResult.OK;
+        }
 
         statusHelper.switchToIndeterminate();
         statusHelper.progress(Bundle.ALeappAnalyzerIngestModule_running_aLeapp());
@@ -466,6 +486,80 @@ public class ALeappAnalyzerIngestModule implements DataSourceIngestModule {
                         filePath.toString(), aLeappFile.getId()), ex); //NON-NLS
             }
         }
+    }
+
+    /**
+     * Determines whether the data source appears to be from an Android device.
+     * For disk images, checks filesystem types first (fast, no I/O). Ext2/3/4
+     * and YAFFS2 are Android-positive; NTFS, HFS, and APFS are
+     * Android-negative. FAT-only or ambiguous images, and logical file sets,
+     * fall through to a file-based check.
+     *
+     * @param dataSource the data source to evaluate
+     *
+     * @return true if the data source appears to be Android
+     */
+    private boolean isAndroidDataSource(Content dataSource) {
+        if (dataSource instanceof Image) {
+            try {
+                boolean hasAndroidFs = false;
+                boolean hasDefinitelyNonAndroidFs = false;
+                for (FileSystem fs : ((Image) dataSource).getFileSystems()) {
+                    switch (fs.getFsType()) {
+                        case TSK_FS_TYPE_EXT2:
+                        case TSK_FS_TYPE_EXT3:
+                        case TSK_FS_TYPE_EXT4:
+                        case TSK_FS_TYPE_EXT_DETECT:
+                        case TSK_FS_TYPE_YAFFS2:
+                        case TSK_FS_TYPE_YAFFS2_DETECT:
+                            hasAndroidFs = true;
+                            break;
+                        case TSK_FS_TYPE_NTFS:
+                        case TSK_FS_TYPE_NTFS_DETECT:
+                        case TSK_FS_TYPE_HFS:
+                        case TSK_FS_TYPE_HFS_DETECT:
+                        case TSK_FS_TYPE_APFS:
+                        case TSK_FS_TYPE_APFS_DETECT:
+                            hasDefinitelyNonAndroidFs = true;
+                            break;
+                        default:
+                            break;
+                    }
+                }
+                if (hasAndroidFs) {
+                    return true;
+                }
+                if (hasDefinitelyNonAndroidFs) {
+                    return false;
+                }
+                // FAT-only or no recognized FS: fall through to file check
+            } catch (TskCoreException ex) {
+                logger.log(Level.WARNING, "Error checking filesystem types for aLeapp Android detection", ex); //NON-NLS
+            }
+        }
+        return hasAndroidIndicatorFiles(dataSource);
+    }
+
+    /**
+     * Searches for a small set of files that are present on virtually all
+     * Android devices. Returns true as soon as any one is found.
+     *
+     * @param dataSource the data source to search
+     *
+     * @return true if at least one Android indicator file is found
+     */
+    private boolean hasAndroidIndicatorFiles(Content dataSource) {
+        FileManager fileManager = getCurrentCase().getServices().getFileManager();
+        for (String[] fileInfo : ANDROID_INDICATOR_FILES) {
+            try {
+                if (!fileManager.findFiles(dataSource, fileInfo[0], fileInfo[1]).isEmpty()) {
+                    return true;
+                }
+            } catch (TskCoreException ex) {
+                logger.log(Level.WARNING, String.format("Error searching for Android indicator file '%s'", fileInfo[0]), ex); //NON-NLS
+            }
+        }
+        return false;
     }
 
     /**

--- a/Core/src/org/sleuthkit/autopsy/modules/leappanalyzers/ALeappAnalyzerIngestModule.java
+++ b/Core/src/org/sleuthkit/autopsy/modules/leappanalyzers/ALeappAnalyzerIngestModule.java
@@ -506,12 +506,12 @@ public class ALeappAnalyzerIngestModule implements DataSourceIngestModule {
                 boolean hasDefinitelyNonAndroidFs = false;
                 for (FileSystem fs : ((Image) dataSource).getFileSystems()) {
                     switch (fs.getFsType()) {
-                        case TSK_FS_TYPE_EXT2:
                         case TSK_FS_TYPE_EXT3:
                         case TSK_FS_TYPE_EXT4:
-                        case TSK_FS_TYPE_EXT_DETECT:
                         case TSK_FS_TYPE_YAFFS2:
                         case TSK_FS_TYPE_YAFFS2_DETECT:
+                            // EXT3/4 and YAFFS2 are strongly associated with Android;
+                            // no further indicator-file check needed.
                             hasAndroidFs = true;
                             break;
                         case TSK_FS_TYPE_NTFS:
@@ -557,6 +557,7 @@ public class ALeappAnalyzerIngestModule implements DataSourceIngestModule {
                 }
             } catch (TskCoreException ex) {
                 logger.log(Level.WARNING, String.format("Error searching for Android indicator file '%s'", fileInfo[0]), ex); //NON-NLS
+                return true; // Fail open: an inconclusive search is not a negative result.
             }
         }
         return false;

--- a/Core/src/org/sleuthkit/autopsy/modules/leappanalyzers/ILeappAnalyzerIngestModule.java
+++ b/Core/src/org/sleuthkit/autopsy/modules/leappanalyzers/ILeappAnalyzerIngestModule.java
@@ -28,6 +28,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Locale;
@@ -54,9 +55,12 @@ import org.sleuthkit.autopsy.ingest.IngestServices;
 import org.sleuthkit.autopsy.ingest.IngestModule.IngestModuleException;
 import org.sleuthkit.datamodel.AbstractFile;
 import org.sleuthkit.datamodel.Content;
+import org.sleuthkit.datamodel.FileSystem;
+import org.sleuthkit.datamodel.Image;
 import org.sleuthkit.datamodel.LocalFilesDataSource;
 import org.sleuthkit.datamodel.ReadContentInputStream;
 import org.sleuthkit.datamodel.TskCoreException;
+import org.sleuthkit.datamodel.TskData;
 
 /**
  * Data source ingest module that runs iLeapp against logical iOS files.
@@ -72,6 +76,14 @@ public class ILeappAnalyzerIngestModule implements DataSourceIngestModule {
     private static final String ILEAPP_PATHS_FILE = "iLeapp_paths.txt"; //NON-NLS
 
     private static final String XMLFILE = "ileapp-artifact-attribute-reference.xml"; //NON-NLS
+
+    // iOS-specific files used to detect whether the data source is from an iOS device.
+    // All three live under /private/var/mobile/, a path that does not exist on macOS.
+    // Filename and parent-path pairs searched in order; finding any one is sufficient.
+    private static final List<String[]> IOS_INDICATOR_FILES = Arrays.asList(
+            new String[]{"sms.db", "/private/var/mobile/Library/SMS/"},                           //NON-NLS
+            new String[]{"AddressBook.sqlitedb", "/private/var/mobile/Library/AddressBook/"},     //NON-NLS
+            new String[]{"com.apple.mobilephone.plist", "/private/var/mobile/Library/Preferences/"}); //NON-NLS
 
     private File iLeappExecutable;
 
@@ -122,9 +134,18 @@ public class ILeappAnalyzerIngestModule implements DataSourceIngestModule {
         "ILeappAnalyzerIngestModule.has.run=iLeapp",
         "ILeappAnalyzerIngestModule.iLeapp.cancelled=iLeapp run was canceled",
         "ILeappAnalyzerIngestModule.completed=iLeapp Processing Completed",
-        "ILeappAnalyzerIngestModule.report.name=iLeapp Html Report"})
+        "ILeappAnalyzerIngestModule.report.name=iLeapp Html Report",
+        "ILeappAnalyzerIngestModule.notIOS.skipped=iLeapp skipped: data source does not appear to be an iOS device."})
     @Override
     public ProcessResult process(Content dataSource, DataSourceIngestModuleProgress statusHelper) {
+
+        if (!isIOSDataSource(dataSource)) {
+            logger.log(Level.INFO, "iLeapp: data source does not appear to be iOS, skipping."); //NON-NLS
+            IngestMessage message = IngestMessage.createMessage(IngestMessage.MessageType.DATA,
+                    MODULE_NAME, Bundle.ILeappAnalyzerIngestModule_notIOS_skipped());
+            IngestServices.getInstance().postMessage(message);
+            return ProcessResult.OK;
+        }
 
         statusHelper.switchToIndeterminate();
         statusHelper.progress(Bundle.ILeappAnalyzerIngestModule_running_iLeapp());
@@ -495,6 +516,71 @@ public class ILeappAnalyzerIngestModule implements DataSourceIngestModule {
                         filePath.toString(), iLeappFile.getId()), ex); //NON-NLS
             }
         }
+    }
+
+    /**
+     * Determines whether the data source appears to be from an iOS device.
+     * For disk images, rules out clearly non-iOS filesystem types first (fast,
+     * no I/O): Ext2/3/4, YAFFS2 (Android), and NTFS (Windows) are
+     * iOS-negative. HFS and APFS are ambiguous (also used by macOS) and fall
+     * through to a file-based check. FAT and unknown types also fall through.
+     *
+     * @param dataSource the data source to evaluate
+     *
+     * @return true if the data source appears to be iOS
+     */
+    private boolean isIOSDataSource(Content dataSource) {
+        if (dataSource instanceof Image) {
+            try {
+                boolean hasDefinitelyNonIOSFs = false;
+                for (FileSystem fs : ((Image) dataSource).getFileSystems()) {
+                    switch (fs.getFsType()) {
+                        case TSK_FS_TYPE_EXT2:
+                        case TSK_FS_TYPE_EXT3:
+                        case TSK_FS_TYPE_EXT4:
+                        case TSK_FS_TYPE_EXT_DETECT:
+                        case TSK_FS_TYPE_YAFFS2:
+                        case TSK_FS_TYPE_YAFFS2_DETECT:
+                        case TSK_FS_TYPE_NTFS:
+                        case TSK_FS_TYPE_NTFS_DETECT:
+                            hasDefinitelyNonIOSFs = true;
+                            break;
+                        default:
+                            break;
+                    }
+                }
+                if (hasDefinitelyNonIOSFs) {
+                    return false;
+                }
+                // HFS, APFS, FAT, or unknown: fall through to file check
+            } catch (TskCoreException ex) {
+                logger.log(Level.WARNING, "Error checking filesystem types for iLeapp iOS detection", ex); //NON-NLS
+            }
+        }
+        return hasIOSIndicatorFiles(dataSource);
+    }
+
+    /**
+     * Searches for a small set of files that are present on virtually all iOS
+     * devices under /private/var/mobile/, a path that does not exist on macOS.
+     * Returns true as soon as any one is found.
+     *
+     * @param dataSource the data source to search
+     *
+     * @return true if at least one iOS indicator file is found
+     */
+    private boolean hasIOSIndicatorFiles(Content dataSource) {
+        FileManager fileManager = getCurrentCase().getServices().getFileManager();
+        for (String[] fileInfo : IOS_INDICATOR_FILES) {
+            try {
+                if (!fileManager.findFiles(dataSource, fileInfo[0], fileInfo[1]).isEmpty()) {
+                    return true;
+                }
+            } catch (TskCoreException ex) {
+                logger.log(Level.WARNING, String.format("Error searching for iOS indicator file '%s'", fileInfo[0]), ex); //NON-NLS
+            }
+        }
+        return false;
     }
 
     /**

--- a/Core/src/org/sleuthkit/autopsy/modules/leappanalyzers/ILeappAnalyzerIngestModule.java
+++ b/Core/src/org/sleuthkit/autopsy/modules/leappanalyzers/ILeappAnalyzerIngestModule.java
@@ -78,12 +78,15 @@ public class ILeappAnalyzerIngestModule implements DataSourceIngestModule {
     private static final String XMLFILE = "ileapp-artifact-attribute-reference.xml"; //NON-NLS
 
     // iOS-specific files used to detect whether the data source is from an iOS device.
-    // All three live under /private/var/mobile/, a path that does not exist on macOS.
-    // Filename and parent-path pairs searched in order; finding any one is sufficient.
+    // Entries cover both /private/var/mobile/ (canonical) and /var/mobile/ (symlinked path
+    // that some acquisition tools use). Finding any one file is sufficient.
     private static final List<String[]> IOS_INDICATOR_FILES = Arrays.asList(
-            new String[]{"sms.db", "/private/var/mobile/Library/SMS/"},                           //NON-NLS
-            new String[]{"AddressBook.sqlitedb", "/private/var/mobile/Library/AddressBook/"},     //NON-NLS
-            new String[]{"com.apple.mobilephone.plist", "/private/var/mobile/Library/Preferences/"}); //NON-NLS
+            new String[]{"sms.db", "/private/var/mobile/Library/SMS/"},                                //NON-NLS
+            new String[]{"sms.db", "/var/mobile/Library/SMS/"},                                        //NON-NLS
+            new String[]{"AddressBook.sqlitedb", "/private/var/mobile/Library/AddressBook/"},          //NON-NLS
+            new String[]{"AddressBook.sqlitedb", "/var/mobile/Library/AddressBook/"},                  //NON-NLS
+            new String[]{"com.apple.mobilephone.plist", "/private/var/mobile/Library/Preferences/"},   //NON-NLS
+            new String[]{"com.apple.mobilephone.plist", "/var/mobile/Library/Preferences/"});          //NON-NLS
 
     private File iLeappExecutable;
 
@@ -562,8 +565,8 @@ public class ILeappAnalyzerIngestModule implements DataSourceIngestModule {
 
     /**
      * Searches for a small set of files that are present on virtually all iOS
-     * devices under /private/var/mobile/, a path that does not exist on macOS.
-     * Returns true as soon as any one is found.
+     * devices under /private/var/mobile/ or /var/mobile/ (symlinked path used
+     * by some acquisition tools). Returns true as soon as any one is found.
      *
      * @param dataSource the data source to search
      *
@@ -578,6 +581,7 @@ public class ILeappAnalyzerIngestModule implements DataSourceIngestModule {
                 }
             } catch (TskCoreException ex) {
                 logger.log(Level.WARNING, String.format("Error searching for iOS indicator file '%s'", fileInfo[0]), ex); //NON-NLS
+                return true; // Fail open: an inconclusive search is not a negative result.
             }
         }
         return false;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Android analyzer now skips non-Android data sources and posts a skip notification.
  * iOS analyzer now skips non-iOS data sources and posts a skip notification.
* **New Features**
  * Improved platform detection using filesystem-type checks and indicator-file scanning for more accurate skipping; uncertain detections log a warning and favor continuing processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->