### PR TITLE
Swich to TSK_JAVA_LIB_PATH

### DIFF
--- a/Core/build.xml
+++ b/Core/build.xml
@@ -130,7 +130,7 @@
     
     <target name="getTSKJars" depends="findTSK">
         <property environment="env"/>
-        <copy file="${env.TSK_HOME}/bindings/java/dist/sleuthkit-${TSK_VERSION}.jar" 
+        <copy file="${env.TSK_JAVA_LIB_PATH}/sleuthkit-${TSK_VERSION}.jar"
               tofile="${ext.dir}/sleuthkit-${TSK_VERSION}.jar"/>
         <copy file="${env.TSK_HOME}/bindings/java/lib/sqlite-jdbc-3.49.1.0.jar"
               tofile="${ext.dir}/sqlite-jdbc-3.49.1.0.jar"/>
@@ -142,7 +142,7 @@
               tofile="${ext.dir}/mchange-commons-java-0.3.2.jar"/>
         <copy file="${env.TSK_HOME}/bindings/java/lib/SparseBitSet-1.3.jar"
               tofile="${ext.dir}/SparseBitSet-1.3.jar"/>	
-        <copy file="${env.TSK_HOME}/case-uco/java/dist/sleuthkit-caseuco-${TSK_VERSION}.jar" 
+        <copy file="${env.TSK_JAVA_LIB_PATH}/sleuthkit-caseuco-${TSK_VERSION}.jar"
               tofile="${ext.dir}/sleuthkit-caseuco-${TSK_VERSION}.jar"/>  
     </target>
 


### PR DESCRIPTION
I don't claim this is a real fix but It's more an attempt to discuss the expected path).


It seems like autopsy buildsys expects some artefacts in more or less arbitrary locations. This is an attempt to try to understand. In sleuthkit I don't have any indication (IIRC) to where install theses artefacts, but I expect system package to have them in a dedicated TSK_HOME sub-directory. I've choosen this for the sleuthkit package.
TSK_HOME=/usr/share/tsk

Autopsy, then would expect the files to be in:
${TSK_HOME}/binding/java/dist   
... for sleuthkit-%{version}.jar
and  %{tsk_home}/case-uco/java/dist/
... for sleuthkit-caseuco-%{version}.jar

But then I don't get why they need to be in a separate directories... So I'm using TSK_JAVA_LIB_PATH in order to get the sleuthkit to install them directly in the right directory.



(side note: the sleuthkit in fedora/rhel have been updated to latest, but are still missing the java binding required by autopsy by default).
See also https://koji.fedoraproject.org/koji/packageinfo?packageID=6420